### PR TITLE
Move pytest from production to dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel build
-          python -m pip install -e .
+          python -m pip install -e ".[dev]"
 
       - name: Build package
         run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,18 @@ description = "Minimal tracer-bullet data pipeline for learning data engineering
 requires-python = ">=3.9"
 dependencies = [
   "pandas>=2.0",
-  "pyarrow>=14.0",
   "duckdb>=0.10",
-  "plotly>=5.18",
-  "ijson>=3.2",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
+dev = [
+  "pytest>=8.0",
+  "fastavro>=1.9",
+  "ijson>=3.2",
+  "pyarrow>=14.0",
+  "plotly>=5.18",
+  "streamlit>=1.30",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ dependencies = [
   "pandas>=2.0",
   "pyarrow>=14.0",
   "duckdb>=0.10",
-  "fastavro>=1.9",
-  "streamlit>=1.30",
   "plotly>=5.18",
   "ijson>=3.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ dependencies = [
   "streamlit>=1.30",
   "plotly>=5.18",
   "ijson>=3.2",
-  "pytest>=8.0",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -45,6 +45,8 @@ def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, p
 
     for row in validated_frame.to_dict(orient="records"):
         versions = json_loads_if_needed(row["versions"])
+        if not versions:
+            raise ValueError(f"paper {row['id']} has no versions")
         latest_version_number = max(version["version_number"] for version in versions)
 
         for version in versions:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
+from email.utils import format_datetime
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +17,7 @@ def make_arxiv_record(identifier: int, *, version_count: int = 1, year: int = 20
         versions.append(
             {
                 "version": f"v{index + 1}",
-                "created": f"{year + index:04d}-{month:02d}-{day:02d}",
+                "created": format_datetime(datetime(year + index, month, day)),
             }
         )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import pytest
 import pandas as pd
 
 from data_learning.ingest_stage import normalize_record
-from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, run_model
+from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, run_model
 
 from tests.helpers import make_arxiv_record
 
@@ -30,3 +31,9 @@ def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
     assert fact_frame["is_first_submission"].tolist() == [True, False, True]
     assert fact_frame["is_latest_version"].tolist() == [False, True, True]
     assert date_frame["date_key"].tolist() == [20200101, 20210101, 20210202]
+
+
+def test_build_fact_and_dates_raises_on_empty_versions():
+    frame = pd.DataFrame([{"id": "0000001", "versions": "[]"}])
+    with pytest.raises(ValueError, match="no versions"):
+        build_fact_and_dates(frame)


### PR DESCRIPTION
## Summary
- Move `pytest` from production dependencies to `[project.optional-dependencies].dev`
- Move other unused production deps (`fastavro`, `ijson`, `pyarrow`, `plotly`, `streamlit`) to `dev` extras — only `pandas` and `duckdb` are actually imported
- Update CI workflow to `pip install -e ".[dev]"` so pytest is available in Actions
- Switch test fixture dates from ISO to RFC 2822 format to exercise the primary `parse_created_date` code path (matching real arXiv data)
- Add explicit `ValueError` guard in `build_fact_and_dates` for empty version lists instead of a cryptic `max()` error

## Test plan
- [ ] `python -m pytest tests/` — all 7 tests pass
- [ ] CI passes with the updated install command
- [ ] `pip install -e .` only pulls in `pandas` and `duckdb`
- [ ] `pip install -e ".[dev]"` pulls in pytest plus deferred deps