### PR TITLE
Implement full ingestion validation and remove leaked planning terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This repository is a local learning project for a staged data-engineering pipeline over arXiv metadata. The current implementation is the narrow tracer bullet for issue `#3`, not the full Phase 1 spec.
+This repository is a local learning project for a staged data-engineering pipeline over arXiv metadata. The current implementation includes full Stage 1 ingestion plus a narrower partial implementation of later stages, not the full Phase 1 spec.
 
 When making changes, preserve that distinction unless the user explicitly asks to expand scope.
 
@@ -15,16 +15,16 @@ When making changes, preserve that distinction unless the user explicitly asks t
   - `src/store.py`
   - `src/query.py`
   - shared logic under `src/data_learning/`
+  - full ingestion validation/logging that writes validated raw Parquet
   - stage tests and one end-to-end CLI smoke test
 - Not implemented yet:
-  - full ingestion validation/reporting
   - `dim_papers`
   - authors/categories dimensions and bridge tables
   - SCD Type 2 logic
   - Avro output and benchmarks
   - dashboard/UI
 
-Do not quietly introduce later-scope features while touching the tracer bullet.
+Do not quietly introduce later-scope features while touching the current partial Phase 1 implementation.
 
 ## Working conventions
 
@@ -43,7 +43,7 @@ PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
 
 - Keep the CLI entrypoints in `src/` thin; put reusable behavior in `src/data_learning/`.
 - Favor explicit path arguments and deterministic outputs so tests can run against temp directories.
-- Preserve the current tracer-bullet fact schema unless the user explicitly requests the next modeling issue:
+- Preserve the current implemented fact schema unless the user explicitly requests the next modeling issue:
   - `submission_key`
   - `paper_id`
   - `version_number`

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # data-learning
 
-Minimal tracer-bullet data pipeline for learning data engineering concepts with the arXiv metadata dataset.
+Local data pipeline project for learning data engineering concepts with the arXiv metadata dataset.
 
-This repository currently implements issue `#3`: a thin end-to-end slice that proves the local pipeline shape works before the fuller Phase 1 project is built out.
+This repository currently implements full Stage 1 ingestion from issue `#4`, plus a narrower partial implementation of later stages while the rest of Phase 1 is still being built out.
 
 ## Current scope
 
-The implemented pipeline processes a small sample of the raw arXiv JSONL snapshot through four stages:
+The implemented pipeline currently covers the four stages below, with Stage 1 implemented fully and later stages still intentionally minimal:
 
-1. `ingest`: read JSONL, keep the first 100 valid records, and write validated Parquet
+1. `ingest`: stream JSONL, validate records, log drops, and write validated Parquet
 2. `model`: build a minimal `fact_submissions` table and `dim_dates`
 3. `store`: write `fact_submissions` to CSV and Parquet outputs
 4. `query`: run one DuckDB query for submission counts by year
 
-This is intentionally narrower than the full Phase 1 spec. It does not yet include full validation/logging, `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
+The repository is still narrower than the full Phase 1 spec. It does not yet include `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
 
 ## Project layout
 
@@ -186,7 +186,7 @@ This is the most explicit and beginner-friendly option because every command cle
 
 ```bash
 ./.venv/bin/python --version
-./.venv/bin/pytest -q
+PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
 ```
 
 This README mostly uses that style.
@@ -232,8 +232,7 @@ If your file lives somewhere else, pass a different path with `--input`.
 ```bash
 ./.venv/bin/python src/ingest.py \
   --input data/arxiv-metadata-oai-snapshot.json \
-  --output data/raw/arxiv_validated.parquet \
-  --limit 100
+  --output data/raw/arxiv_validated.parquet
 ```
 
 ### 2. Model
@@ -269,7 +268,7 @@ year    submission_count
 
 ## Outputs
 
-The current tracer bullet writes:
+The current implementation writes:
 
 - `data/raw/arxiv_validated.parquet`
 - `data/modeled/fact_submissions.parquet`
@@ -301,7 +300,7 @@ If you just want a safe, repeatable local workflow on macOS, use this:
 python3 -m venv .venv
 ./.venv/bin/pip install --upgrade pip setuptools wheel
 ./.venv/bin/pip install -e .
-./.venv/bin/pytest -q
+PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
 ./.venv/bin/python src/ingest.py --help
 ```
 

--- a/docs/batching.md
+++ b/docs/batching.md
@@ -1,0 +1,73 @@
+# Ingest Batching
+
+This note explains the batching pattern used by Stage 1 ingestion in [`src/data_learning/ingest_stage.py`](/Users/brian/dev/data-learning/src/data_learning/ingest_stage.py).
+
+## Read path
+
+Input is read one line at a time from the JSONL snapshot:
+
+- the file handle is opened once
+- each non-empty line is parsed with `json.loads(...)`
+- each parsed record is validated immediately
+
+This means reads are streamed. The ingest stage does not load the full source file into memory.
+
+## Write path
+
+Writes are batched separately from reads.
+
+For each valid record:
+
+1. the normalized record is appended to `buffered_rows`
+2. once `len(buffered_rows) >= batch_size`, the batch is written to the open `pyarrow.parquet.ParquetWriter`
+3. the in-memory buffer is cleared
+
+At end of file, the remaining partial batch is written once more.
+
+## Current batch size
+
+The current default write batch size is `10_000` rows, defined as `DEFAULT_BATCH_SIZE` in [`src/data_learning/ingest_stage.py`](/Users/brian/dev/data-learning/src/data_learning/ingest_stage.py).
+
+That means:
+
+- full batches are written in chunks of 10,000 valid rows
+- the final flush is whatever remains, from 1 to 9,999 rows
+- if `--limit` is used, the last batch may be smaller than the default size
+
+## Why this helps
+
+This pattern keeps memory bounded compared with collecting every validated row before writing output.
+
+It also preserves the simple semantics of a batch job:
+
+- one bounded input snapshot
+- one deterministic output file
+- reruns can rewrite the target from the beginning
+
+That is much simpler than a streaming system where the code has to reason about duplicate events, checkpoint recovery, and idempotent event-by-event writes.
+
+## Memory tradeoff
+
+The code is memory-safe relative to the full dataset, but it is not memory-free.
+
+Peak memory for the write side is driven by:
+
+- `batch_size`
+- average size of each normalized record
+- temporary conversion overhead when `buffered_rows` is converted into a PyArrow table
+
+So a larger batch improves write amortization, but it also increases peak memory use. If records become much larger, reducing `batch_size` lowers the memory ceiling.
+
+## Why reading line by line is not enough by itself
+
+Streaming reads only solve half of the problem.
+
+Even if input is parsed one line at a time, memory can still grow too large if validated rows are accumulated without a write flush. The separate write buffer is what keeps output-side memory bounded.
+
+## Future hardening options
+
+If Stage 1 needs tighter operational controls later, reasonable next steps would be:
+
+- make `batch_size` configurable from the CLI
+- benchmark different batch sizes on the full dataset
+- track approximate buffer size in bytes instead of only row count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "data-learning"
 version = "0.1.0"
-description = "Minimal tracer-bullet data pipeline for learning data engineering concepts."
+description = "Local data pipeline project for learning data engineering concepts."
 requires-python = ">=3.9"
 dependencies = [
   "pandas>=2.0",
   "duckdb>=0.10",
+  "pyarrow>=14.0",
 ]
 
 [project.optional-dependencies]
@@ -17,7 +18,6 @@ dev = [
   "pytest>=8.0",
   "fastavro>=1.9",
   "ijson>=3.2",
-  "pyarrow>=14.0",
   "plotly>=5.18",
   "streamlit>=1.30",
 ]

--- a/src/data_learning/__init__.py
+++ b/src/data_learning/__init__.py
@@ -1,4 +1,4 @@
-"""Shared pipeline modules for the arXiv tracer-bullet project."""
+"""Shared pipeline modules for the arXiv learning project."""
 
 __all__ = [
     "common",

--- a/src/data_learning/ingest_stage.py
+++ b/src/data_learning/ingest_stage.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
+import time
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
-import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from data_learning.common import (
     DEFAULT_RAW_INPUT_PATH,
     DEFAULT_VALIDATED_PATH,
-    dump_json,
     ensure_parent_directory,
     parse_created_date,
     parse_version_number,
@@ -33,68 +36,163 @@ OUTPUT_COLUMNS = [
 ]
 
 REQUIRED_FIELDS = ("id", "title", "authors_parsed", "categories", "versions")
+DEFAULT_BATCH_SIZE = 10_000
+DROP_SAMPLE_LIMIT = 5
+
+LOGGER = logging.getLogger(__name__)
+
+VALIDATED_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string()),
+        pa.field("submitter", pa.string()),
+        pa.field("title", pa.string()),
+        pa.field("authors_parsed", pa.list_(pa.list_(pa.string()))),
+        pa.field("categories", pa.string()),
+        pa.field(
+            "versions",
+            pa.list_(
+                pa.struct(
+                    [
+                        pa.field("version", pa.string()),
+                        pa.field("created", pa.string()),
+                    ]
+                )
+            ),
+        ),
+        pa.field("abstract", pa.string()),
+        pa.field("doi", pa.string()),
+        pa.field("journal_ref", pa.string()),
+        pa.field("comments", pa.string()),
+        pa.field("license", pa.string()),
+        pa.field("update_date", pa.string()),
+    ]
+)
 
 
-def normalize_record(record: dict[str, Any]) -> dict[str, Any] | None:
+def normalize_record(record: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(record, dict):
+        return None, "invalid_record_type"
+
     for field in REQUIRED_FIELDS:
         if field not in record or record[field] in (None, "", []):
-            return None
+            return None, f"missing_{field}"
 
     categories = record.get("categories")
     if not isinstance(categories, str) or not categories.strip():
-        return None
+        return None, "invalid_categories"
 
     authors_parsed = record.get("authors_parsed")
     if not isinstance(authors_parsed, list) or not authors_parsed:
-        return None
+        return None, "invalid_authors_parsed"
+
+    normalized_authors: list[list[str]] = []
+    for author in authors_parsed:
+        if not isinstance(author, (list, tuple)) or not author:
+            return None, "invalid_authors_parsed"
+        normalized_authors.append(
+            [None if value is None else str(value) for value in author]
+        )
 
     versions = record.get("versions")
     if not isinstance(versions, list) or not versions:
-        return None
+        return None, "invalid_versions"
 
-    normalized_versions: list[dict[str, Any]] = []
+    normalized_versions: list[dict[str, str | None]] = []
     for version in versions:
         if not isinstance(version, dict):
-            return None
+            return None, "invalid_versions"
 
-        version_number = parse_version_number(version.get("version"))
-        created_date = parse_created_date(version.get("created"))
-        if version_number is None or created_date is None:
-            return None
+        raw_version = version.get("version")
+        raw_created = version.get("created")
+        if parse_version_number(raw_version) is None:
+            return None, "invalid_versions"
+        if parse_created_date(raw_created) is None:
+            return None, "invalid_version_created"
 
         normalized_versions.append(
             {
-                "version": version.get("version"),
-                "version_number": version_number,
-                "created_date": created_date.isoformat(),
+                "version": str(raw_version),
+                "created": str(raw_created),
             }
         )
 
-    normalized_versions.sort(key=lambda item: item["version_number"])
+    normalized_versions.sort(key=lambda item: parse_version_number(item["version"]) or 0)
 
-    return {
-        "id": record.get("id"),
-        "submitter": record.get("submitter"),
-        "title": record.get("title"),
-        "authors_parsed": dump_json(authors_parsed),
-        "categories": categories.strip(),
-        "versions": dump_json(normalized_versions),
-        "abstract": record.get("abstract"),
-        "doi": record.get("doi"),
-        "journal_ref": record.get("journal-ref"),
-        "comments": record.get("comments"),
-        "license": record.get("license"),
-        "update_date": record.get("update_date"),
-    }
+    return (
+        {
+            "id": str(record.get("id")),
+            "submitter": record.get("submitter"),
+            "title": str(record.get("title")),
+            "authors_parsed": normalized_authors,
+            "categories": categories.strip(),
+            "versions": normalized_versions,
+            "abstract": record.get("abstract"),
+            "doi": record.get("doi"),
+            "journal_ref": record.get("journal-ref"),
+            "comments": record.get("comments"),
+            "license": record.get("license"),
+            "update_date": record.get("update_date"),
+        },
+        None,
+    )
 
 
-def collect_validated_rows(input_path: Path, limit: int) -> tuple[list[dict[str, Any]], dict[str, int]]:
-    rows: list[dict[str, Any]] = []
+def _write_batch(writer: pq.ParquetWriter, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    batch_rows = [{column: row.get(column) for column in OUTPUT_COLUMNS} for row in rows]
+    table = pa.Table.from_pylist(batch_rows, schema=VALIDATED_SCHEMA)
+    writer.write_table(table)
+
+
+def _log_summary(
+    *,
+    input_path: Path,
+    output_path: Path,
+    total_read: int,
+    valid_records: int,
+    dropped_records: int,
+    drop_reasons: Counter[str],
+    drop_samples: list[dict[str, Any]],
+    elapsed_seconds: float,
+) -> None:
+    LOGGER.info(
+        "Ingested %s -> %s in %.2fs (read=%d, valid=%d, dropped=%d)",
+        input_path,
+        output_path,
+        elapsed_seconds,
+        total_read,
+        valid_records,
+        dropped_records,
+    )
+    LOGGER.info("Drop reasons: %s", dict(sorted(drop_reasons.items())))
+    if drop_samples:
+        LOGGER.info("Sample dropped records: %s", drop_samples)
+
+
+def run_ingest(
+    input_path: Path,
+    output_path: Path,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> dict[str, Any]:
+    ensure_parent_directory(output_path)
+    started_at = time.perf_counter()
+    drop_reasons: Counter[str] = Counter()
+    drop_samples: list[dict[str, Any]] = []
+    buffered_rows: list[dict[str, Any]] = []
     total_read = 0
-    dropped_records = 0
+    valid_records = 0
 
-    with input_path.open("r", encoding="utf-8") as handle:
-        for raw_line in handle:
+    # This stage reads a bounded snapshot, so a batch scan is the right fit here.
+    # A streaming variant would handle unbounded new submissions through a long-lived consumer.
+    # In Lambda terms this is only the batch layer; a Kappa design would replay both history and
+    # new submissions through one streaming path instead of splitting batch and speed paths.
+    with input_path.open("r", encoding="utf-8") as handle, pq.ParquetWriter(
+        output_path,
+        VALIDATED_SCHEMA,
+    ) as writer:
+        for line_number, raw_line in enumerate(handle, start=1):
             line = raw_line.strip()
             if not line:
                 continue
@@ -103,52 +201,72 @@ def collect_validated_rows(input_path: Path, limit: int) -> tuple[list[dict[str,
             try:
                 parsed = json.loads(line)
             except json.JSONDecodeError:
-                dropped_records += 1
+                reason = "invalid_json"
+                drop_reasons[reason] += 1
+                if len(drop_samples) < DROP_SAMPLE_LIMIT:
+                    drop_samples.append({"line": line_number, "reason": reason})
                 continue
 
-            normalized = normalize_record(parsed)
+            normalized, reason = normalize_record(parsed)
             if normalized is None:
-                dropped_records += 1
+                drop_reasons[reason or "invalid_record"] += 1
+                if len(drop_samples) < DROP_SAMPLE_LIMIT:
+                    sample = {"line": line_number, "reason": reason or "invalid_record"}
+                    if isinstance(parsed, dict):
+                        sample["id"] = parsed.get("id")
+                    drop_samples.append(sample)
                 continue
 
-            rows.append(normalized)
-            if len(rows) >= limit:
+            buffered_rows.append(normalized)
+            valid_records += 1
+
+            # Batched writes keep memory bounded while still giving this batch job predictable,
+            # rerunnable output semantics. That simplicity is the batch version of exactly-once.
+            if len(buffered_rows) >= batch_size:
+                _write_batch(writer, buffered_rows)
+                buffered_rows.clear()
+
+            if limit is not None and valid_records >= limit:
                 break
 
-    stats = {
+        _write_batch(writer, buffered_rows)
+
+    elapsed_seconds = time.perf_counter() - started_at
+    dropped_records = total_read - valid_records
+    _log_summary(
+        input_path=input_path,
+        output_path=output_path,
+        total_read=total_read,
+        valid_records=valid_records,
+        dropped_records=dropped_records,
+        drop_reasons=drop_reasons,
+        drop_samples=drop_samples,
+        elapsed_seconds=elapsed_seconds,
+    )
+    return {
         "total_read": total_read,
-        "valid_records": len(rows),
+        "valid_records": valid_records,
         "dropped_records": dropped_records,
+        "drop_reasons": dict(sorted(drop_reasons.items())),
+        "elapsed_seconds": elapsed_seconds,
     }
-    return rows, stats
-
-
-def write_validated_parquet(rows: list[dict[str, Any]], output_path: Path) -> None:
-    ensure_parent_directory(output_path)
-    dataframe = pd.DataFrame(rows, columns=OUTPUT_COLUMNS)
-    dataframe.to_parquet(output_path, index=False)
-
-
-def run_ingest(input_path: Path, output_path: Path, limit: int = 100) -> dict[str, int]:
-    rows, stats = collect_validated_rows(input_path=input_path, limit=limit)
-    write_validated_parquet(rows=rows, output_path=output_path)
-    return stats
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate arXiv JSONL input and write Parquet output.")
     parser.add_argument("--input", type=path_arg, default=DEFAULT_RAW_INPUT_PATH, help="Path to the raw JSONL file.")
     parser.add_argument("--output", type=path_arg, default=DEFAULT_VALIDATED_PATH, help="Path to the validated Parquet output.")
-    parser.add_argument("--limit", type=int, default=100, help="Number of valid records to process.")
+    parser.add_argument("--limit", type=int, default=None, help="Optional cap on valid records to process.")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     args = build_parser().parse_args(argv)
     stats = run_ingest(input_path=args.input, output_path=args.output, limit=args.limit)
     print(
         f"Validated {stats['valid_records']} records "
-        f"(read={stats['total_read']}, dropped={stats['dropped_records']}) "
+        f"(read={stats['total_read']}, dropped={stats['dropped_records']}, elapsed={stats['elapsed_seconds']:.2f}s) "
         f"-> {args.output}"
     )
     return 0

--- a/src/data_learning/ingest_stage.py
+++ b/src/data_learning/ingest_stage.py
@@ -220,8 +220,11 @@ def run_ingest(
             buffered_rows.append(normalized)
             valid_records += 1
 
-            # Batched writes keep memory bounded while still giving this batch job predictable,
-            # rerunnable output semantics. That simplicity is the batch version of exactly-once.
+            # Batched writes keep memory bounded without changing the core delivery model of this
+            # stage: one bounded input snapshot produces one deterministic output file. If a run
+            # fails, we can rerun the whole job and rewrite the target from the start rather than
+            # reasoning about duplicate events, partial checkpoints, or idempotent per-record
+            # commits. That is the batch-world version of "exactly-once" semantics.
             if len(buffered_rows) >= batch_size:
                 _write_batch(writer, buffered_rows)
                 buffered_rows.clear()

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -13,6 +13,8 @@ from data_learning.common import (
     date_to_key,
     ensure_directory,
     json_loads_if_needed,
+    parse_created_date,
+    parse_version_number,
     path_arg,
 )
 
@@ -38,13 +40,45 @@ DATE_COLUMNS = [
 ]
 
 
+def normalize_versions(value: Any) -> list[dict[str, Any]]:
+    raw_versions = json_loads_if_needed(value)
+    if raw_versions is None:
+        return []
+
+    versions = list(raw_versions)
+    normalized_versions: list[dict[str, Any]] = []
+    for version in versions:
+        if not isinstance(version, dict):
+            raise ValueError(f"invalid version payload: {version!r}")
+
+        if "version_number" in version and "created_date" in version:
+            version_number = version["version_number"]
+            created_date = version["created_date"]
+        else:
+            version_number = parse_version_number(version.get("version"))
+            created = parse_created_date(version.get("created"))
+            if version_number is None or created is None:
+                raise ValueError(f"invalid version payload: {version!r}")
+            created_date = created.isoformat()
+
+        normalized_versions.append(
+            {
+                "version_number": version_number,
+                "created_date": created_date,
+            }
+        )
+
+    normalized_versions.sort(key=lambda item: item["version_number"])
+    return normalized_versions
+
+
 def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
     fact_rows: list[dict[str, Any]] = []
     unique_dates: dict[int, date] = {}
     submission_key = 1
 
     for row in validated_frame.to_dict(orient="records"):
-        versions = json_loads_if_needed(row["versions"])
+        versions = normalize_versions(row["versions"])
         if not versions:
             raise ValueError(f"paper {row['id']} has no versions")
         latest_version_number = max(version["version_number"] for version in versions)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import logging
+
 import pandas as pd
+import pytest
 
 from data_learning.ingest_stage import OUTPUT_COLUMNS, run_ingest
 
 from tests.helpers import make_arxiv_record, write_jsonl
 
 
-def test_run_ingest_writes_validated_parquet_and_skips_bad_rows(tmp_path):
+def test_run_ingest_writes_validated_parquet_and_logs_drop_reasons(tmp_path, caplog):
     input_path = tmp_path / "raw.jsonl"
     output_path = tmp_path / "validated.parquet"
 
@@ -16,18 +19,63 @@ def test_run_ingest_writes_validated_parquet_and_skips_bad_rows(tmp_path):
     missing_categories = make_arxiv_record(3)
     missing_categories["categories"] = ""
 
+    caplog.set_level(logging.INFO)
     write_jsonl(
         input_path,
         [valid_a, valid_b, missing_categories],
         extra_lines=["not-json"],
     )
 
-    stats = run_ingest(input_path=input_path, output_path=output_path, limit=10)
+    stats = run_ingest(input_path=input_path, output_path=output_path)
 
     frame = pd.read_parquet(output_path)
-    assert stats == {"total_read": 4, "valid_records": 2, "dropped_records": 2}
+    assert stats["total_read"] == 4
+    assert stats["valid_records"] == 2
+    assert stats["dropped_records"] == 2
+    assert stats["drop_reasons"] == {
+        "invalid_json": 1,
+        "missing_categories": 1,
+    }
+    assert stats["elapsed_seconds"] >= 0
     assert frame.columns.tolist() == OUTPUT_COLUMNS
     assert frame["id"].tolist() == [valid_a["id"], valid_b["id"]]
+    assert [list(author) for author in frame.iloc[0]["authors_parsed"]] == valid_a["authors_parsed"]
+    assert list(frame.iloc[1]["versions"]) == valid_b["versions"]
+    assert "Drop reasons:" in caplog.text
+    assert "Sample dropped records:" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_reason"),
+    [
+        (lambda record: record.pop("id"), "missing_id"),
+        (lambda record: record.pop("title"), "missing_title"),
+        (lambda record: record.pop("authors_parsed"), "missing_authors_parsed"),
+        (lambda record: record.pop("categories"), "missing_categories"),
+        (lambda record: record.pop("versions"), "missing_versions"),
+        (lambda record: record.__setitem__("authors_parsed", []), "missing_authors_parsed"),
+        (lambda record: record.__setitem__("authors_parsed", "Bell, Brian"), "invalid_authors_parsed"),
+        (lambda record: record.__setitem__("categories", "   "), "invalid_categories"),
+        (lambda record: record.__setitem__("versions", []), "missing_versions"),
+        (lambda record: record.__setitem__("versions", "v1"), "invalid_versions"),
+        (lambda record: record.__setitem__("versions", [{"version": "v1", "created": "not-a-date"}]), "invalid_version_created"),
+    ],
+)
+def test_run_ingest_rejects_invalid_records_with_specific_reason(tmp_path, mutator, expected_reason):
+    input_path = tmp_path / "raw.jsonl"
+    output_path = tmp_path / "validated.parquet"
+
+    record = make_arxiv_record(1)
+    mutator(record)
+    write_jsonl(input_path, [record])
+
+    stats = run_ingest(input_path=input_path, output_path=output_path)
+
+    frame = pd.read_parquet(output_path)
+    assert frame.empty
+    assert stats["valid_records"] == 0
+    assert stats["dropped_records"] == 1
+    assert stats["drop_reasons"] == {expected_reason: 1}
 
 
 def test_run_ingest_stops_after_limit_valid_records(tmp_path):
@@ -43,3 +91,17 @@ def test_run_ingest_stops_after_limit_valid_records(tmp_path):
     assert stats["valid_records"] == 3
     assert stats["total_read"] == 3
     assert len(frame) == 3
+
+
+def test_run_ingest_writes_multiple_batches(tmp_path):
+    input_path = tmp_path / "raw.jsonl"
+    output_path = tmp_path / "validated.parquet"
+
+    records = [make_arxiv_record(index, version_count=1, year=2020) for index in range(1, 6)]
+    write_jsonl(input_path, records)
+
+    stats = run_ingest(input_path=input_path, output_path=output_path, batch_size=2)
+
+    frame = pd.read_parquet(output_path)
+    assert stats["valid_records"] == 5
+    assert frame["id"].tolist() == [record["id"] for record in records]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,7 @@ import pytest
 import pandas as pd
 
 from data_learning.ingest_stage import normalize_record
-from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, run_model
+from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, normalize_versions, run_model
 
 from tests.helpers import make_arxiv_record
 
@@ -14,8 +14,8 @@ def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
     output_dir = tmp_path / "modeled"
 
     records = [
-        normalize_record(make_arxiv_record(1, version_count=2, year=2020)),
-        normalize_record(make_arxiv_record(2, version_count=1, year=2021)),
+        normalize_record(make_arxiv_record(1, version_count=2, year=2020))[0],
+        normalize_record(make_arxiv_record(2, version_count=1, year=2021))[0],
     ]
 
     pd.DataFrame(records).to_parquet(input_path, index=False)
@@ -37,3 +37,17 @@ def test_build_fact_and_dates_raises_on_empty_versions():
     frame = pd.DataFrame([{"id": "0000001", "versions": "[]"}])
     with pytest.raises(ValueError, match="no versions"):
         build_fact_and_dates(frame)
+
+
+def test_normalize_versions_accepts_raw_ingest_payload():
+    raw_versions = [
+        {"version": "v2", "created": "Tue, 02 Feb 2021 00:00:00 GMT"},
+        {"version": "v1", "created": "Wed, 01 Jan 2020 00:00:00 GMT"},
+    ]
+
+    normalized = normalize_versions(raw_versions)
+
+    assert normalized == [
+        {"version_number": 1, "created_date": "2020-01-01"},
+        {"version_number": 2, "created_date": "2021-02-02"},
+    ]

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -25,8 +25,6 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
             str(raw_input),
             "--output",
             str(validated_path),
-            "--limit",
-            "100",
         ],
         [
             sys.executable,
@@ -66,7 +64,7 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
         )
 
     validated_frame = pd.read_parquet(validated_path)
-    assert len(validated_frame) == 100
+    assert len(validated_frame) == len(records)
     assert (output_dir / "csv" / "fact_submissions.csv").exists()
     assert (output_dir / "parquet" / "fact_submissions.parquet").exists()
     assert "year\tsubmission_count" in completed[-1].stdout


### PR DESCRIPTION
Closes #4

## Summary

This PR implements issue #4 by replacing the sample-oriented Stage 1 ingest path with full-file validation and streaming Parquet output, while keeping the current Stage 2+ narrow pipeline working against the new validated schema.

## What changed

- rewrote Stage 1 ingest to stream JSONL line by line instead of collecting validated rows in memory
- switched validated output writes to batched `pyarrow.parquet.ParquetWriter` writes
- changed validated raw output to preserve the full Stage 1 schema, including nested `authors_parsed` and raw `versions` payloads
- added explicit validation failure reasons for malformed JSON, missing required fields, invalid categories, invalid author payloads, invalid versions, and unparsable version dates
- added structured ingestion summary logging for totals, drop counts, drop reasons, sample dropped records, and elapsed time
- updated the ingest CLI so full-file processing is the default and `--limit` is now optional
- added inline learning comments in ingest around bounded vs. unbounded data, Lambda vs. Kappa, and batch delivery semantics
- updated the model stage to normalize either the old reduced `versions` payload or the new raw `[{version, created}]` payload so the current end-to-end flow still works
- promoted `pyarrow` to a runtime dependency because validated Parquet output is now part of the core runtime path
- removed repo references to "tracer bullet" from code and documentation and rewrote scope wording to reflect that Stage 1 is implemented while later stages remain partial

## Files of interest

- `src/data_learning/ingest_stage.py`
- `src/data_learning/model_stage.py`
- `tests/test_ingest.py`
- `tests/test_model.py`
- `tests/test_pipeline_smoke.py`
- `README.md`
- `AGENTS.md`

## Automated verification

```bash
PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
```

Result: `20 passed`

## Manual test steps

### 1. Validate the ingest CLI against a temp JSONL file

```bash
python3 -m venv .venv
./.venv/bin/pip install --upgrade pip setuptools wheel
./.venv/bin/pip install -e .
```

Create a small temp input file with one valid row and one invalid row:

```bash
cat > /tmp/arxiv-mini.jsonl <<'EOF2'
{"id":"0000001","submitter":"submitter-1","title":"Paper 1","authors_parsed":[["Bell","Brian",""]],"categories":"cs.AI","versions":[{"version":"v1","created":"Wed, 01 Jan 2020 00:00:00 GMT"}],"abstract":"Abstract 1","doi":null,"journal-ref":null,"comments":null,"license":"CC0","update_date":"2020-01-01"}
{"id":"0000002","submitter":"submitter-2","title":"Paper 2","authors_parsed":[["Bell","Brian",""]],"categories":"cs.AI","versions":[{"version":"v1","created":"not-a-date"}],"abstract":"Abstract 2","doi":null,"journal-ref":null,"comments":null,"license":"CC0","update_date":"2020-01-02"}
EOF2
```

Run ingest:

```bash
./.venv/bin/python src/ingest.py \
  --input /tmp/arxiv-mini.jsonl \
  --output /tmp/arxiv_validated.parquet
```

Confirm expected behavior:

- stdout reports `Validated 1 records`
- log output includes `dropped=1`
- log output includes `invalid_version_created`
- `/tmp/arxiv_validated.parquet` exists

### 2. Confirm the validated Parquet schema contains nested complex columns

```bash
./.venv/bin/python - <<'EOF2'
import pandas as pd
frame = pd.read_parquet('/tmp/arxiv_validated.parquet')
print(frame.columns.tolist())
print(frame.iloc[0]['authors_parsed'])
print(frame.iloc[0]['versions'])
EOF2
```

Confirm expected behavior:

- columns include `authors_parsed` and `versions`
- `authors_parsed` is nested data, not a JSON string
- `versions` contains the raw `version` and `created` values

### 3. Run the current end-to-end CLI flow

Use a temp JSONL fixture with several valid rows, then run:

```bash
./.venv/bin/python src/ingest.py --input /tmp/arxiv-mini.jsonl --output /tmp/raw/arxiv_validated.parquet
./.venv/bin/python src/model.py --input /tmp/raw/arxiv_validated.parquet --output-dir /tmp/modeled
./.venv/bin/python src/store.py --input /tmp/modeled/fact_submissions.parquet --output-dir /tmp/output
./.venv/bin/python src/query.py --fact-path /tmp/output/parquet/fact_submissions.parquet --date-dim-path /tmp/modeled/dim_dates.parquet
```

Confirm expected behavior:

- ingest writes validated Parquet and logs totals/drop reasons
- model writes `fact_submissions.parquet` and `dim_dates.parquet`
- store writes CSV and Parquet outputs
- query prints the tab-separated `year\tsubmission_count` header

## Notes

- I left the untracked `.hypothesis/` directory alone; it is not part of this PR.
