### PR TITLE
Implement core Stage 2 star schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .claude/settings.local.json
 .DS_Store
 __pycache__/
+.hypothesis/
 .pytest_cache/
 .venv/
 *.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This repository is a local learning project for a staged data-engineering pipeline over arXiv metadata. The current implementation is the narrow tracer bullet for issue `#3`, not the full Phase 1 spec.
+This repository is a local learning project for a staged data-engineering pipeline over arXiv metadata. The current implementation includes full Stage 1 ingestion plus a narrower partial implementation of later stages, not the full Phase 1 spec.
 
 When making changes, preserve that distinction unless the user explicitly asks to expand scope.
 
@@ -15,16 +15,16 @@ When making changes, preserve that distinction unless the user explicitly asks t
   - `src/store.py`
   - `src/query.py`
   - shared logic under `src/data_learning/`
+  - full ingestion validation/logging that writes validated raw Parquet
   - stage tests and one end-to-end CLI smoke test
 - Not implemented yet:
-  - full ingestion validation/reporting
   - `dim_papers`
   - authors/categories dimensions and bridge tables
   - SCD Type 2 logic
   - Avro output and benchmarks
   - dashboard/UI
 
-Do not quietly introduce later-scope features while touching the tracer bullet.
+Do not quietly introduce later-scope features while touching the current partial Phase 1 implementation.
 
 ## Working conventions
 
@@ -43,7 +43,7 @@ PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
 
 - Keep the CLI entrypoints in `src/` thin; put reusable behavior in `src/data_learning/`.
 - Favor explicit path arguments and deterministic outputs so tests can run against temp directories.
-- Preserve the current tracer-bullet fact schema unless the user explicitly requests the next modeling issue:
+- Preserve the current implemented fact schema unless the user explicitly requests the next modeling issue:
   - `submission_key`
   - `paper_id`
   - `version_number`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ When making changes, preserve that distinction unless the user explicitly asks t
   - `src/query.py`
   - shared logic under `src/data_learning/`
   - full ingestion validation/logging that writes validated raw Parquet
+  - core Stage 2 star schema outputs: `fact_submissions`, `dim_dates`, `dim_papers`
   - stage tests and one end-to-end CLI smoke test
 - Not implemented yet:
-  - `dim_papers`
   - authors/categories dimensions and bridge tables
   - SCD Type 2 logic
   - Avro output and benchmarks
@@ -47,6 +47,7 @@ PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
   - `submission_key`
   - `paper_id`
   - `version_number`
+  - `paper_key`
   - `date_key`
   - `is_first_submission`
   - `is_latest_version`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+For repository-specific instructions, conventions, and current implementation boundaries, see [AGENTS.md](/Users/brian/dev/data-learning/AGENTS.md).
+
+Treat `AGENTS.md` as the source of truth for this repo.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This repository currently implements full Stage 1 ingestion from issue `#4`, plu
 The implemented pipeline currently covers the four stages below, with Stage 1 implemented fully and later stages still intentionally minimal:
 
 1. `ingest`: stream JSONL, validate records, log drops, and write validated Parquet
-2. `model`: build a minimal `fact_submissions` table and `dim_dates`
+2. `model`: build the core Stage 2 star schema tables `fact_submissions`, `dim_dates`, and `dim_papers`
 3. `store`: write `fact_submissions` to CSV and Parquet outputs
 4. `query`: run one DuckDB query for submission counts by year
 
-The repository is still narrower than the full Phase 1 spec. It does not yet include `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
+The repository is still narrower than the full Phase 1 spec. It does not yet include bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
 
 ## Project layout
 
@@ -273,6 +273,7 @@ The current implementation writes:
 - `data/raw/arxiv_validated.parquet`
 - `data/modeled/fact_submissions.parquet`
 - `data/modeled/dim_dates.parquet`
+- `data/modeled/dim_papers.parquet`
 - `data/output/csv/fact_submissions.csv`
 - `data/output/parquet/fact_submissions.parquet`
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # data-learning
 
-Minimal tracer-bullet data pipeline for learning data engineering concepts with the arXiv metadata dataset.
+Local data pipeline project for learning data engineering concepts with the arXiv metadata dataset.
 
-This repository currently implements issue `#3`: a thin end-to-end slice that proves the local pipeline shape works before the fuller Phase 1 project is built out.
+This repository currently implements full Stage 1 ingestion from issue `#4`, plus a narrower partial implementation of later stages while the rest of Phase 1 is still being built out.
 
 ## Current scope
 
-The implemented pipeline processes a small sample of the raw arXiv JSONL snapshot through four stages:
+The implemented pipeline currently covers the four stages below, with Stage 1 implemented fully and later stages still intentionally minimal:
 
-1. `ingest`: read JSONL, keep the first 100 valid records, and write validated Parquet
+1. `ingest`: stream JSONL, validate records, log drops, and write validated Parquet
 2. `model`: build a minimal `fact_submissions` table and `dim_dates`
 3. `store`: write `fact_submissions` to CSV and Parquet outputs
 4. `query`: run one DuckDB query for submission counts by year
 
-This is intentionally narrower than the full Phase 1 spec. It does not yet include full validation/logging, `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
+The repository is still narrower than the full Phase 1 spec. It does not yet include `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
 
 ## Project layout
 
@@ -186,7 +186,7 @@ This is the most explicit and beginner-friendly option because every command cle
 
 ```bash
 ./.venv/bin/python --version
-./.venv/bin/pytest -q
+PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
 ```
 
 This README mostly uses that style.
@@ -232,8 +232,7 @@ If your file lives somewhere else, pass a different path with `--input`.
 ```bash
 ./.venv/bin/python src/ingest.py \
   --input data/arxiv-metadata-oai-snapshot.json \
-  --output data/raw/arxiv_validated.parquet \
-  --limit 100
+  --output data/raw/arxiv_validated.parquet
 ```
 
 ### 2. Model
@@ -269,7 +268,7 @@ year    submission_count
 
 ## Outputs
 
-The current tracer bullet writes:
+The current implementation writes:
 
 - `data/raw/arxiv_validated.parquet`
 - `data/modeled/fact_submissions.parquet`
@@ -301,7 +300,7 @@ If you just want a safe, repeatable local workflow on macOS, use this:
 python3 -m venv .venv
 ./.venv/bin/pip install --upgrade pip setuptools wheel
 ./.venv/bin/pip install -e .
-./.venv/bin/pytest -q
+PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
 ./.venv/bin/python src/ingest.py --help
 ```
 

--- a/docs/batching.md
+++ b/docs/batching.md
@@ -1,0 +1,73 @@
+# Ingest Batching
+
+This note explains the batching pattern used by Stage 1 ingestion in [`src/data_learning/ingest_stage.py`](/Users/brian/dev/data-learning/src/data_learning/ingest_stage.py).
+
+## Read path
+
+Input is read one line at a time from the JSONL snapshot:
+
+- the file handle is opened once
+- each non-empty line is parsed with `json.loads(...)`
+- each parsed record is validated immediately
+
+This means reads are streamed. The ingest stage does not load the full source file into memory.
+
+## Write path
+
+Writes are batched separately from reads.
+
+For each valid record:
+
+1. the normalized record is appended to `buffered_rows`
+2. once `len(buffered_rows) >= batch_size`, the batch is written to the open `pyarrow.parquet.ParquetWriter`
+3. the in-memory buffer is cleared
+
+At end of file, the remaining partial batch is written once more.
+
+## Current batch size
+
+The current default write batch size is `10_000` rows, defined as `DEFAULT_BATCH_SIZE` in [`src/data_learning/ingest_stage.py`](/Users/brian/dev/data-learning/src/data_learning/ingest_stage.py).
+
+That means:
+
+- full batches are written in chunks of 10,000 valid rows
+- the final flush is whatever remains, from 1 to 9,999 rows
+- if `--limit` is used, the last batch may be smaller than the default size
+
+## Why this helps
+
+This pattern keeps memory bounded compared with collecting every validated row before writing output.
+
+It also preserves the simple semantics of a batch job:
+
+- one bounded input snapshot
+- one deterministic output file
+- reruns can rewrite the target from the beginning
+
+That is much simpler than a streaming system where the code has to reason about duplicate events, checkpoint recovery, and idempotent event-by-event writes.
+
+## Memory tradeoff
+
+The code is memory-safe relative to the full dataset, but it is not memory-free.
+
+Peak memory for the write side is driven by:
+
+- `batch_size`
+- average size of each normalized record
+- temporary conversion overhead when `buffered_rows` is converted into a PyArrow table
+
+So a larger batch improves write amortization, but it also increases peak memory use. If records become much larger, reducing `batch_size` lowers the memory ceiling.
+
+## Why reading line by line is not enough by itself
+
+Streaming reads only solve half of the problem.
+
+Even if input is parsed one line at a time, memory can still grow too large if validated rows are accumulated without a write flush. The separate write buffer is what keeps output-side memory bounded.
+
+## Future hardening options
+
+If Stage 1 needs tighter operational controls later, reasonable next steps would be:
+
+- make `batch_size` configurable from the CLI
+- benchmark different batch sizes on the full dataset
+- track approximate buffer size in bytes instead of only row count

--- a/docs/star-schema.md
+++ b/docs/star-schema.md
@@ -1,0 +1,151 @@
+# Stage 2 Star Schema
+
+This note explains the current Stage 2 modeling design implemented in [`src/data_learning/model_stage.py`](/Users/brian/dev/data-learning/src/data_learning/model_stage.py).
+
+The repository now writes three modeled Parquet tables under `data/modeled/`:
+
+- `fact_submissions.parquet`
+- `dim_dates.parquet`
+- `dim_papers.parquet`
+
+This is the core star schema from issue `#5`. It is intentionally narrower than the full Phase 1 spec: bridge tables and SCD Type 2 behavior are still out of scope.
+
+## Schema overview
+
+### `fact_submissions`
+
+This is the central fact table.
+
+Current grain:
+
+- one row per paper-version submission event
+
+Current columns:
+
+- `submission_key`
+- `paper_id`
+- `version_number`
+- `paper_key`
+- `date_key`
+- `is_first_submission`
+- `is_latest_version`
+
+Why this grain:
+
+- the raw arXiv data already expresses version history as repeated version entries per paper
+- one row per paper-version keeps that submission history explicit
+- analytical queries such as "how many updates happened" or "which submissions were latest" become simple filters and counts
+
+Tradeoff:
+
+- this creates more fact rows than a one-row-per-paper model
+- but the extra rows reflect real submission events, which is the more useful analytical shape for this project
+
+### `dim_papers`
+
+This dimension has one row per unique `paper_id`.
+
+Current columns:
+
+- `paper_key`
+- `paper_id`
+- `title`
+- `abstract`
+- `doi`
+- `journal_ref`
+- `comments`
+- `license`
+- `valid_from`
+- `valid_to`
+- `is_current`
+
+Implementation choice:
+
+- `paper_key` is a surrogate key assigned deterministically from sorted `paper_id` values
+- `valid_from`, `valid_to`, and `is_current` are present now as placeholders for later SCD work
+- for issue `#5`, every paper row is current, `valid_to` is null, and `valid_from` is the first submission date
+
+Tradeoff:
+
+- this is not a full historical dimension yet
+- but it keeps the schema compatible with the next modeling issue without pretending SCD Type 2 is already implemented
+
+### `dim_dates`
+
+This is a calendar dimension keyed by `date_key` in `YYYYMMDD` form.
+
+Current columns:
+
+- `date_key`
+- `full_date`
+- `year`
+- `quarter`
+- `month`
+- `month_name`
+- `day_of_week`
+- `day_name`
+- `is_weekend`
+
+Implementation choice:
+
+- the dimension is generated for every calendar day from the earliest submission date to the latest submission date, inclusive
+- it is not limited to dates that appear directly in the fact table
+
+Tradeoff:
+
+- this writes more rows than a sparse "observed dates only" table
+- but it makes the date dimension behave like a real analytic calendar dimension and supports simpler joins and future reporting
+
+## Why a star schema here
+
+Stage 2 uses a star schema rather than a snowflake design.
+
+Reasons:
+
+- the main queries are analytical and join-driven, not OLTP updates
+- denormalized dimensions are easier to understand in a learning project
+- a star schema keeps the relationship between events and dimensions visible without extra join depth
+
+Tradeoff:
+
+- a snowflake model could reduce some duplication inside dimensions
+- but it would add complexity without improving the current query patterns or learning goals
+
+## Surrogate keys versus natural keys
+
+The model keeps both:
+
+- `paper_id` as the natural arXiv identifier
+- `paper_key` as the warehouse-style surrogate key
+
+Why both exist:
+
+- `paper_id` is readable and maps directly back to the source data
+- `paper_key` gives the model a stable dimension join key
+- surrogate keys are the standard pattern once dimensions may need historical versioning
+
+Tradeoff:
+
+- keeping both keys adds one more column to the fact table
+- but it avoids repainting the schema later when SCD logic is added
+
+## Determinism and testability
+
+The current implementation favors deterministic outputs:
+
+- `paper_key` assignment is based on sorted `paper_id`
+- all modeled outputs are written from explicit input and output paths
+- tests can build temporary fixtures and assert exact row values
+
+This is a good fit for a local batch pipeline because reruns should produce the same outputs from the same validated input.
+
+## Known limits of the current implementation
+
+What is intentionally not implemented yet:
+
+- SCD Type 2 behavior in `dim_papers`
+- author and category dimensions
+- bridge tables for paper-author and paper-category relationships
+- later storage-format and dashboard work from later stages
+
+That boundary matters because the current code should describe the implemented core star schema accurately without implying the rest of Phase 1 already exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "data-learning"
 version = "0.1.0"
-description = "Minimal tracer-bullet data pipeline for learning data engineering concepts."
+description = "Local data pipeline project for learning data engineering concepts."
 requires-python = ">=3.9"
 dependencies = [
   "pandas>=2.0",
   "duckdb>=0.10",
+  "pyarrow>=14.0",
 ]
 
 [project.optional-dependencies]
@@ -17,7 +18,6 @@ dev = [
   "pytest>=8.0",
   "fastavro>=1.9",
   "ijson>=3.2",
-  "pyarrow>=14.0",
   "plotly>=5.18",
   "streamlit>=1.30",
 ]

--- a/src/data_learning/__init__.py
+++ b/src/data_learning/__init__.py
@@ -1,4 +1,4 @@
-"""Shared pipeline modules for the arXiv tracer-bullet project."""
+"""Shared pipeline modules for the arXiv learning project."""
 
 __all__ = [
     "common",

--- a/src/data_learning/ingest_stage.py
+++ b/src/data_learning/ingest_stage.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
+import time
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
-import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from data_learning.common import (
     DEFAULT_RAW_INPUT_PATH,
     DEFAULT_VALIDATED_PATH,
-    dump_json,
     ensure_parent_directory,
     parse_created_date,
     parse_version_number,
@@ -33,68 +36,163 @@ OUTPUT_COLUMNS = [
 ]
 
 REQUIRED_FIELDS = ("id", "title", "authors_parsed", "categories", "versions")
+DEFAULT_BATCH_SIZE = 10_000
+DROP_SAMPLE_LIMIT = 5
+
+LOGGER = logging.getLogger(__name__)
+
+VALIDATED_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string()),
+        pa.field("submitter", pa.string()),
+        pa.field("title", pa.string()),
+        pa.field("authors_parsed", pa.list_(pa.list_(pa.string()))),
+        pa.field("categories", pa.string()),
+        pa.field(
+            "versions",
+            pa.list_(
+                pa.struct(
+                    [
+                        pa.field("version", pa.string()),
+                        pa.field("created", pa.string()),
+                    ]
+                )
+            ),
+        ),
+        pa.field("abstract", pa.string()),
+        pa.field("doi", pa.string()),
+        pa.field("journal_ref", pa.string()),
+        pa.field("comments", pa.string()),
+        pa.field("license", pa.string()),
+        pa.field("update_date", pa.string()),
+    ]
+)
 
 
-def normalize_record(record: dict[str, Any]) -> dict[str, Any] | None:
+def normalize_record(record: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(record, dict):
+        return None, "invalid_record_type"
+
     for field in REQUIRED_FIELDS:
         if field not in record or record[field] in (None, "", []):
-            return None
+            return None, f"missing_{field}"
 
     categories = record.get("categories")
     if not isinstance(categories, str) or not categories.strip():
-        return None
+        return None, "invalid_categories"
 
     authors_parsed = record.get("authors_parsed")
     if not isinstance(authors_parsed, list) or not authors_parsed:
-        return None
+        return None, "invalid_authors_parsed"
+
+    normalized_authors: list[list[str]] = []
+    for author in authors_parsed:
+        if not isinstance(author, (list, tuple)) or not author:
+            return None, "invalid_authors_parsed"
+        normalized_authors.append(
+            [None if value is None else str(value) for value in author]
+        )
 
     versions = record.get("versions")
     if not isinstance(versions, list) or not versions:
-        return None
+        return None, "invalid_versions"
 
-    normalized_versions: list[dict[str, Any]] = []
+    normalized_versions: list[dict[str, str | None]] = []
     for version in versions:
         if not isinstance(version, dict):
-            return None
+            return None, "invalid_versions"
 
-        version_number = parse_version_number(version.get("version"))
-        created_date = parse_created_date(version.get("created"))
-        if version_number is None or created_date is None:
-            return None
+        raw_version = version.get("version")
+        raw_created = version.get("created")
+        if parse_version_number(raw_version) is None:
+            return None, "invalid_versions"
+        if parse_created_date(raw_created) is None:
+            return None, "invalid_version_created"
 
         normalized_versions.append(
             {
-                "version": version.get("version"),
-                "version_number": version_number,
-                "created_date": created_date.isoformat(),
+                "version": str(raw_version),
+                "created": str(raw_created),
             }
         )
 
-    normalized_versions.sort(key=lambda item: item["version_number"])
+    normalized_versions.sort(key=lambda item: parse_version_number(item["version"]) or 0)
 
-    return {
-        "id": record.get("id"),
-        "submitter": record.get("submitter"),
-        "title": record.get("title"),
-        "authors_parsed": dump_json(authors_parsed),
-        "categories": categories.strip(),
-        "versions": dump_json(normalized_versions),
-        "abstract": record.get("abstract"),
-        "doi": record.get("doi"),
-        "journal_ref": record.get("journal-ref"),
-        "comments": record.get("comments"),
-        "license": record.get("license"),
-        "update_date": record.get("update_date"),
-    }
+    return (
+        {
+            "id": str(record.get("id")),
+            "submitter": record.get("submitter"),
+            "title": str(record.get("title")),
+            "authors_parsed": normalized_authors,
+            "categories": categories.strip(),
+            "versions": normalized_versions,
+            "abstract": record.get("abstract"),
+            "doi": record.get("doi"),
+            "journal_ref": record.get("journal-ref"),
+            "comments": record.get("comments"),
+            "license": record.get("license"),
+            "update_date": record.get("update_date"),
+        },
+        None,
+    )
 
 
-def collect_validated_rows(input_path: Path, limit: int) -> tuple[list[dict[str, Any]], dict[str, int]]:
-    rows: list[dict[str, Any]] = []
+def _write_batch(writer: pq.ParquetWriter, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    batch_rows = [{column: row.get(column) for column in OUTPUT_COLUMNS} for row in rows]
+    table = pa.Table.from_pylist(batch_rows, schema=VALIDATED_SCHEMA)
+    writer.write_table(table)
+
+
+def _log_summary(
+    *,
+    input_path: Path,
+    output_path: Path,
+    total_read: int,
+    valid_records: int,
+    dropped_records: int,
+    drop_reasons: Counter[str],
+    drop_samples: list[dict[str, Any]],
+    elapsed_seconds: float,
+) -> None:
+    LOGGER.info(
+        "Ingested %s -> %s in %.2fs (read=%d, valid=%d, dropped=%d)",
+        input_path,
+        output_path,
+        elapsed_seconds,
+        total_read,
+        valid_records,
+        dropped_records,
+    )
+    LOGGER.info("Drop reasons: %s", dict(sorted(drop_reasons.items())))
+    if drop_samples:
+        LOGGER.info("Sample dropped records: %s", drop_samples)
+
+
+def run_ingest(
+    input_path: Path,
+    output_path: Path,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> dict[str, Any]:
+    ensure_parent_directory(output_path)
+    started_at = time.perf_counter()
+    drop_reasons: Counter[str] = Counter()
+    drop_samples: list[dict[str, Any]] = []
+    buffered_rows: list[dict[str, Any]] = []
     total_read = 0
-    dropped_records = 0
+    valid_records = 0
 
-    with input_path.open("r", encoding="utf-8") as handle:
-        for raw_line in handle:
+    # This stage reads a bounded snapshot, so a batch scan is the right fit here.
+    # A streaming variant would handle unbounded new submissions through a long-lived consumer.
+    # In Lambda terms this is only the batch layer; a Kappa design would replay both history and
+    # new submissions through one streaming path instead of splitting batch and speed paths.
+    with input_path.open("r", encoding="utf-8") as handle, pq.ParquetWriter(
+        output_path,
+        VALIDATED_SCHEMA,
+    ) as writer:
+        for line_number, raw_line in enumerate(handle, start=1):
             line = raw_line.strip()
             if not line:
                 continue
@@ -103,52 +201,72 @@ def collect_validated_rows(input_path: Path, limit: int) -> tuple[list[dict[str,
             try:
                 parsed = json.loads(line)
             except json.JSONDecodeError:
-                dropped_records += 1
+                reason = "invalid_json"
+                drop_reasons[reason] += 1
+                if len(drop_samples) < DROP_SAMPLE_LIMIT:
+                    drop_samples.append({"line": line_number, "reason": reason})
                 continue
 
-            normalized = normalize_record(parsed)
+            normalized, reason = normalize_record(parsed)
             if normalized is None:
-                dropped_records += 1
+                drop_reasons[reason or "invalid_record"] += 1
+                if len(drop_samples) < DROP_SAMPLE_LIMIT:
+                    sample = {"line": line_number, "reason": reason or "invalid_record"}
+                    if isinstance(parsed, dict):
+                        sample["id"] = parsed.get("id")
+                    drop_samples.append(sample)
                 continue
 
-            rows.append(normalized)
-            if len(rows) >= limit:
+            buffered_rows.append(normalized)
+            valid_records += 1
+
+            # Batched writes keep memory bounded while still giving this batch job predictable,
+            # rerunnable output semantics. That simplicity is the batch version of exactly-once.
+            if len(buffered_rows) >= batch_size:
+                _write_batch(writer, buffered_rows)
+                buffered_rows.clear()
+
+            if limit is not None and valid_records >= limit:
                 break
 
-    stats = {
+        _write_batch(writer, buffered_rows)
+
+    elapsed_seconds = time.perf_counter() - started_at
+    dropped_records = total_read - valid_records
+    _log_summary(
+        input_path=input_path,
+        output_path=output_path,
+        total_read=total_read,
+        valid_records=valid_records,
+        dropped_records=dropped_records,
+        drop_reasons=drop_reasons,
+        drop_samples=drop_samples,
+        elapsed_seconds=elapsed_seconds,
+    )
+    return {
         "total_read": total_read,
-        "valid_records": len(rows),
+        "valid_records": valid_records,
         "dropped_records": dropped_records,
+        "drop_reasons": dict(sorted(drop_reasons.items())),
+        "elapsed_seconds": elapsed_seconds,
     }
-    return rows, stats
-
-
-def write_validated_parquet(rows: list[dict[str, Any]], output_path: Path) -> None:
-    ensure_parent_directory(output_path)
-    dataframe = pd.DataFrame(rows, columns=OUTPUT_COLUMNS)
-    dataframe.to_parquet(output_path, index=False)
-
-
-def run_ingest(input_path: Path, output_path: Path, limit: int = 100) -> dict[str, int]:
-    rows, stats = collect_validated_rows(input_path=input_path, limit=limit)
-    write_validated_parquet(rows=rows, output_path=output_path)
-    return stats
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate arXiv JSONL input and write Parquet output.")
     parser.add_argument("--input", type=path_arg, default=DEFAULT_RAW_INPUT_PATH, help="Path to the raw JSONL file.")
     parser.add_argument("--output", type=path_arg, default=DEFAULT_VALIDATED_PATH, help="Path to the validated Parquet output.")
-    parser.add_argument("--limit", type=int, default=100, help="Number of valid records to process.")
+    parser.add_argument("--limit", type=int, default=None, help="Optional cap on valid records to process.")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     args = build_parser().parse_args(argv)
     stats = run_ingest(input_path=args.input, output_path=args.output, limit=args.limit)
     print(
         f"Validated {stats['valid_records']} records "
-        f"(read={stats['total_read']}, dropped={stats['dropped_records']}) "
+        f"(read={stats['total_read']}, dropped={stats['dropped_records']}, elapsed={stats['elapsed_seconds']:.2f}s) "
         f"-> {args.output}"
     )
     return 0

--- a/src/data_learning/ingest_stage.py
+++ b/src/data_learning/ingest_stage.py
@@ -220,8 +220,11 @@ def run_ingest(
             buffered_rows.append(normalized)
             valid_records += 1
 
-            # Batched writes keep memory bounded while still giving this batch job predictable,
-            # rerunnable output semantics. That simplicity is the batch version of exactly-once.
+            # Batched writes keep memory bounded without changing the core delivery model of this
+            # stage: one bounded input snapshot produces one deterministic output file. If a run
+            # fails, we can rerun the whole job and rewrite the target from the start rather than
+            # reasoning about duplicate events, partial checkpoints, or idempotent per-record
+            # commits. That is the batch-world version of "exactly-once" semantics.
             if len(buffered_rows) >= batch_size:
                 _write_batch(writer, buffered_rows)
                 buffered_rows.clear()

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -13,6 +13,8 @@ from data_learning.common import (
     date_to_key,
     ensure_directory,
     json_loads_if_needed,
+    parse_created_date,
+    parse_version_number,
     path_arg,
 )
 
@@ -38,13 +40,45 @@ DATE_COLUMNS = [
 ]
 
 
+def normalize_versions(value: Any) -> list[dict[str, Any]]:
+    raw_versions = json_loads_if_needed(value)
+    if raw_versions is None:
+        return []
+
+    versions = list(raw_versions)
+    normalized_versions: list[dict[str, Any]] = []
+    for version in versions:
+        if not isinstance(version, dict):
+            raise ValueError(f"invalid version payload: {version!r}")
+
+        if "version_number" in version and "created_date" in version:
+            version_number = version["version_number"]
+            created_date = version["created_date"]
+        else:
+            version_number = parse_version_number(version.get("version"))
+            created = parse_created_date(version.get("created"))
+            if version_number is None or created is None:
+                raise ValueError(f"invalid version payload: {version!r}")
+            created_date = created.isoformat()
+
+        normalized_versions.append(
+            {
+                "version_number": version_number,
+                "created_date": created_date,
+            }
+        )
+
+    normalized_versions.sort(key=lambda item: item["version_number"])
+    return normalized_versions
+
+
 def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
     fact_rows: list[dict[str, Any]] = []
     unique_dates: dict[int, date] = {}
     submission_key = 1
 
     for row in validated_frame.to_dict(orient="records"):
-        versions = json_loads_if_needed(row["versions"])
+        versions = normalize_versions(row["versions"])
         if not versions:
             raise ValueError(f"paper {row['id']} has no versions")
         latest_version_number = max(version["version_number"] for version in versions)

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -22,9 +22,24 @@ FACT_COLUMNS = [
     "submission_key",
     "paper_id",
     "version_number",
+    "paper_key",
     "date_key",
     "is_first_submission",
     "is_latest_version",
+]
+
+PAPER_COLUMNS = [
+    "paper_key",
+    "paper_id",
+    "title",
+    "abstract",
+    "doi",
+    "journal_ref",
+    "comments",
+    "license",
+    "valid_from",
+    "valid_to",
+    "is_current",
 ]
 
 DATE_COLUMNS = [
@@ -72,12 +87,77 @@ def normalize_versions(value: Any) -> list[dict[str, Any]]:
     return normalized_versions
 
 
-def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+def build_date_dimension(start_date: date | None, end_date: date | None) -> pd.DataFrame:
+    if start_date is None or end_date is None:
+        return pd.DataFrame(columns=DATE_COLUMNS)
+
+    date_rows = []
+    current_date = start_date
+    while current_date <= end_date:
+        date_rows.append(
+            {
+                "date_key": date_to_key(current_date),
+                "full_date": current_date.isoformat(),
+                "year": current_date.year,
+                "quarter": ((current_date.month - 1) // 3) + 1,
+                "month": current_date.month,
+                "month_name": current_date.strftime("%B"),
+                "day_of_week": current_date.weekday(),
+                "day_name": current_date.strftime("%A"),
+                "is_weekend": current_date.weekday() >= 5,
+            }
+        )
+        current_date += timedelta(days=1)
+
+    return pd.DataFrame(date_rows, columns=DATE_COLUMNS)
+
+
+def build_paper_dimension(records: list[dict[str, Any]]) -> tuple[pd.DataFrame, dict[str, int]]:
+    paper_rows: list[dict[str, Any]] = []
+    paper_keys: dict[str, int] = {}
+
+    for paper_key, row in enumerate(sorted(records, key=lambda item: item["id"]), start=1):
+        paper_id = row["id"]
+        if paper_id in paper_keys:
+            raise ValueError(f"duplicate paper id: {paper_id}")
+
+        versions = normalize_versions(row["versions"])
+        if not versions:
+            raise ValueError(f"paper {paper_id} has no versions")
+
+        first_submission_date = date.fromisoformat(versions[0]["created_date"])
+        paper_keys[paper_id] = paper_key
+        paper_rows.append(
+            {
+                "paper_key": paper_key,
+                "paper_id": paper_id,
+                "title": row.get("title"),
+                "abstract": row.get("abstract"),
+                "doi": row.get("doi"),
+                "journal_ref": row.get("journal_ref"),
+                "comments": row.get("comments"),
+                "license": row.get("license"),
+                "valid_from": first_submission_date.isoformat(),
+                "valid_to": None,
+                "is_current": True,
+            }
+        )
+
+    return pd.DataFrame(paper_rows, columns=PAPER_COLUMNS), paper_keys
+
+
+def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    records = validated_frame.to_dict(orient="records")
+    paper_frame, paper_keys = build_paper_dimension(records)
+
     fact_rows: list[dict[str, Any]] = []
-    unique_dates: dict[int, date] = {}
+    min_submission_date: date | None = None
+    max_submission_date: date | None = None
     submission_key = 1
 
-    for row in validated_frame.to_dict(orient="records"):
+    # The fact table grain is one submission event per paper-version. Keeping the fact at that
+    # event grain makes version history explicit without forcing query-time array parsing.
+    for row in records:
         versions = normalize_versions(row["versions"])
         if not versions:
             raise ValueError(f"paper {row['id']} has no versions")
@@ -86,12 +166,16 @@ def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, p
         for version in versions:
             created_date = date.fromisoformat(version["created_date"])
             date_key = date_to_key(created_date)
-            unique_dates[date_key] = created_date
+            min_submission_date = created_date if min_submission_date is None else min(min_submission_date, created_date)
+            max_submission_date = created_date if max_submission_date is None else max(max_submission_date, created_date)
             fact_rows.append(
                 {
                     "submission_key": submission_key,
                     "paper_id": row["id"],
                     "version_number": version["version_number"],
+                    # The natural arXiv id stays on the fact for readability, but the surrogate
+                    # key gives us a stable join target for dimensional modeling and later SCD work.
+                    "paper_key": paper_keys[row["id"]],
                     "date_key": date_key,
                     "is_first_submission": version["version_number"] == 1,
                     "is_latest_version": version["version_number"] == latest_version_number,
@@ -100,52 +184,52 @@ def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, p
             submission_key += 1
 
     fact_frame = pd.DataFrame(fact_rows, columns=FACT_COLUMNS)
-
-    date_rows = []
-    for date_key, full_date in sorted(unique_dates.items()):
-        date_rows.append(
-            {
-                "date_key": date_key,
-                "full_date": full_date.isoformat(),
-                "year": full_date.year,
-                "quarter": ((full_date.month - 1) // 3) + 1,
-                "month": full_date.month,
-                "month_name": full_date.strftime("%B"),
-                "day_of_week": full_date.weekday(),
-                "day_name": full_date.strftime("%A"),
-                "is_weekend": full_date.weekday() >= 5,
-            }
-        )
-
-    date_frame = pd.DataFrame(date_rows, columns=DATE_COLUMNS)
-    return fact_frame, date_frame
+    # This stays a star schema instead of snowflaking further because the learning goal here is
+    # straightforward analytical joins over a small set of conformed dimensions, not extra
+    # normalization depth that would add joins without clarifying the query model.
+    date_frame = build_date_dimension(min_submission_date, max_submission_date)
+    return fact_frame, date_frame, paper_frame
 
 
-def write_modeled_outputs(fact_frame: pd.DataFrame, date_frame: pd.DataFrame, output_dir: Path) -> dict[str, Path]:
+def write_modeled_outputs(
+    fact_frame: pd.DataFrame,
+    date_frame: pd.DataFrame,
+    paper_frame: pd.DataFrame,
+    output_dir: Path,
+) -> dict[str, Path]:
     ensure_directory(output_dir)
     fact_path = output_dir / "fact_submissions.parquet"
     date_path = output_dir / "dim_dates.parquet"
+    paper_path = output_dir / "dim_papers.parquet"
     fact_frame.to_parquet(fact_path, index=False)
     date_frame.to_parquet(date_path, index=False)
+    paper_frame.to_parquet(paper_path, index=False)
     return {
         "fact_submissions": fact_path,
         "dim_dates": date_path,
+        "dim_papers": paper_path,
     }
 
 
 def run_model(input_path: Path, output_dir: Path) -> dict[str, Any]:
     validated_frame = pd.read_parquet(input_path)
-    fact_frame, date_frame = build_fact_and_dates(validated_frame)
-    outputs = write_modeled_outputs(fact_frame=fact_frame, date_frame=date_frame, output_dir=output_dir)
+    fact_frame, date_frame, paper_frame = build_fact_and_dates(validated_frame)
+    outputs = write_modeled_outputs(
+        fact_frame=fact_frame,
+        date_frame=date_frame,
+        paper_frame=paper_frame,
+        output_dir=output_dir,
+    )
     return {
         "fact_rows": len(fact_frame),
         "date_rows": len(date_frame),
+        "paper_rows": len(paper_frame),
         "outputs": outputs,
     }
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build minimal fact and date dimensions from validated data.")
+    parser = argparse.ArgumentParser(description="Build core star schema tables from validated data.")
     parser.add_argument("--input", type=path_arg, default=DEFAULT_VALIDATED_PATH, help="Path to the validated Parquet input.")
     parser.add_argument("--output-dir", type=path_arg, default=DEFAULT_MODELED_DIR, help="Directory for modeled Parquet outputs.")
     return parser
@@ -155,7 +239,8 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     result = run_model(input_path=args.input, output_dir=args.output_dir)
     print(
-        f"Created {result['fact_rows']} fact rows and {result['date_rows']} date rows "
+        f"Created {result['fact_rows']} fact rows, {result['date_rows']} date rows, "
+        f"and {result['paper_rows']} paper rows "
         f"under {args.output_dir}"
     )
     return 0

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import logging
+
 import pandas as pd
+import pytest
 
 from data_learning.ingest_stage import OUTPUT_COLUMNS, run_ingest
 
 from tests.helpers import make_arxiv_record, write_jsonl
 
 
-def test_run_ingest_writes_validated_parquet_and_skips_bad_rows(tmp_path):
+def test_run_ingest_writes_validated_parquet_and_logs_drop_reasons(tmp_path, caplog):
     input_path = tmp_path / "raw.jsonl"
     output_path = tmp_path / "validated.parquet"
 
@@ -16,18 +19,63 @@ def test_run_ingest_writes_validated_parquet_and_skips_bad_rows(tmp_path):
     missing_categories = make_arxiv_record(3)
     missing_categories["categories"] = ""
 
+    caplog.set_level(logging.INFO)
     write_jsonl(
         input_path,
         [valid_a, valid_b, missing_categories],
         extra_lines=["not-json"],
     )
 
-    stats = run_ingest(input_path=input_path, output_path=output_path, limit=10)
+    stats = run_ingest(input_path=input_path, output_path=output_path)
 
     frame = pd.read_parquet(output_path)
-    assert stats == {"total_read": 4, "valid_records": 2, "dropped_records": 2}
+    assert stats["total_read"] == 4
+    assert stats["valid_records"] == 2
+    assert stats["dropped_records"] == 2
+    assert stats["drop_reasons"] == {
+        "invalid_json": 1,
+        "missing_categories": 1,
+    }
+    assert stats["elapsed_seconds"] >= 0
     assert frame.columns.tolist() == OUTPUT_COLUMNS
     assert frame["id"].tolist() == [valid_a["id"], valid_b["id"]]
+    assert [list(author) for author in frame.iloc[0]["authors_parsed"]] == valid_a["authors_parsed"]
+    assert list(frame.iloc[1]["versions"]) == valid_b["versions"]
+    assert "Drop reasons:" in caplog.text
+    assert "Sample dropped records:" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_reason"),
+    [
+        (lambda record: record.pop("id"), "missing_id"),
+        (lambda record: record.pop("title"), "missing_title"),
+        (lambda record: record.pop("authors_parsed"), "missing_authors_parsed"),
+        (lambda record: record.pop("categories"), "missing_categories"),
+        (lambda record: record.pop("versions"), "missing_versions"),
+        (lambda record: record.__setitem__("authors_parsed", []), "missing_authors_parsed"),
+        (lambda record: record.__setitem__("authors_parsed", "Bell, Brian"), "invalid_authors_parsed"),
+        (lambda record: record.__setitem__("categories", "   "), "invalid_categories"),
+        (lambda record: record.__setitem__("versions", []), "missing_versions"),
+        (lambda record: record.__setitem__("versions", "v1"), "invalid_versions"),
+        (lambda record: record.__setitem__("versions", [{"version": "v1", "created": "not-a-date"}]), "invalid_version_created"),
+    ],
+)
+def test_run_ingest_rejects_invalid_records_with_specific_reason(tmp_path, mutator, expected_reason):
+    input_path = tmp_path / "raw.jsonl"
+    output_path = tmp_path / "validated.parquet"
+
+    record = make_arxiv_record(1)
+    mutator(record)
+    write_jsonl(input_path, [record])
+
+    stats = run_ingest(input_path=input_path, output_path=output_path)
+
+    frame = pd.read_parquet(output_path)
+    assert frame.empty
+    assert stats["valid_records"] == 0
+    assert stats["dropped_records"] == 1
+    assert stats["drop_reasons"] == {expected_reason: 1}
 
 
 def test_run_ingest_stops_after_limit_valid_records(tmp_path):
@@ -43,3 +91,17 @@ def test_run_ingest_stops_after_limit_valid_records(tmp_path):
     assert stats["valid_records"] == 3
     assert stats["total_read"] == 3
     assert len(frame) == 3
+
+
+def test_run_ingest_writes_multiple_batches(tmp_path):
+    input_path = tmp_path / "raw.jsonl"
+    output_path = tmp_path / "validated.parquet"
+
+    records = [make_arxiv_record(index, version_count=1, year=2020) for index in range(1, 6)]
+    write_jsonl(input_path, records)
+
+    stats = run_ingest(input_path=input_path, output_path=output_path, batch_size=2)
+
+    frame = pd.read_parquet(output_path)
+    assert stats["valid_records"] == 5
+    assert frame["id"].tolist() == [record["id"] for record in records]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,12 +4,19 @@ import pytest
 import pandas as pd
 
 from data_learning.ingest_stage import normalize_record
-from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, normalize_versions, run_model
+from data_learning.model_stage import (
+    DATE_COLUMNS,
+    FACT_COLUMNS,
+    PAPER_COLUMNS,
+    build_fact_and_dates,
+    normalize_versions,
+    run_model,
+)
 
 from tests.helpers import make_arxiv_record
 
 
-def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
+def test_run_model_builds_core_star_schema_tables(tmp_path):
     input_path = tmp_path / "validated.parquet"
     output_dir = tmp_path / "modeled"
 
@@ -24,19 +31,76 @@ def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
 
     fact_frame = pd.read_parquet(output_dir / "fact_submissions.parquet")
     date_frame = pd.read_parquet(output_dir / "dim_dates.parquet")
+    paper_frame = pd.read_parquet(output_dir / "dim_papers.parquet")
+    expected_dates = pd.date_range("2020-01-01", "2021-02-02", freq="D")
 
     assert result["fact_rows"] == 3
+    assert result["paper_rows"] == 2
+    assert result["date_rows"] == len(expected_dates)
+    assert set(result["outputs"]) == {"fact_submissions", "dim_dates", "dim_papers"}
     assert fact_frame.columns.tolist() == FACT_COLUMNS
     assert date_frame.columns.tolist() == DATE_COLUMNS
+    assert paper_frame.columns.tolist() == PAPER_COLUMNS
+    assert fact_frame["paper_key"].tolist() == [1, 1, 2]
     assert fact_frame["is_first_submission"].tolist() == [True, False, True]
     assert fact_frame["is_latest_version"].tolist() == [False, True, True]
-    assert date_frame["date_key"].tolist() == [20200101, 20210101, 20210202]
+    assert date_frame["date_key"].tolist()[0] == 20200101
+    assert date_frame["date_key"].tolist()[-1] == 20210202
+    assert paper_frame.to_dict(orient="records") == [
+        {
+            "paper_key": 1,
+            "paper_id": "0000001",
+            "title": "Paper 1",
+            "abstract": "Abstract for paper 1",
+            "doi": None,
+            "journal_ref": None,
+            "comments": None,
+            "license": "CC0",
+            "valid_from": "2020-01-01",
+            "valid_to": None,
+            "is_current": True,
+        },
+        {
+            "paper_key": 2,
+            "paper_id": "0000002",
+            "title": "Paper 2",
+            "abstract": "Abstract for paper 2",
+            "doi": None,
+            "journal_ref": None,
+            "comments": None,
+            "license": "CC0",
+            "valid_from": "2021-01-01",
+            "valid_to": None,
+            "is_current": True,
+        },
+    ]
 
 
 def test_build_fact_and_dates_raises_on_empty_versions():
     frame = pd.DataFrame([{"id": "0000001", "versions": "[]"}])
     with pytest.raises(ValueError, match="no versions"):
         build_fact_and_dates(frame)
+
+
+def test_build_fact_and_dates_uses_valid_dimension_keys():
+    frame = pd.DataFrame(
+        [
+            normalize_record(make_arxiv_record(2, version_count=3, year=2020))[0],
+            normalize_record(make_arxiv_record(1, version_count=1, year=2021))[0],
+        ]
+    )
+
+    fact_frame, date_frame, paper_frame = build_fact_and_dates(frame)
+
+    assert len(fact_frame) == 4
+    assert len(paper_frame) == 2
+    assert len(fact_frame) >= len(paper_frame)
+    assert set(fact_frame["paper_key"]) == set(paper_frame["paper_key"])
+    assert set(fact_frame["date_key"]).issubset(set(date_frame["date_key"]))
+    assert fact_frame["version_number"].tolist() == [1, 2, 3, 1]
+    assert fact_frame["paper_key"].tolist() == [2, 2, 2, 1]
+    assert fact_frame["is_first_submission"].tolist() == [True, False, False, True]
+    assert fact_frame["is_latest_version"].tolist() == [False, False, True, True]
 
 
 def test_normalize_versions_accepts_raw_ingest_payload():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,7 @@ import pytest
 import pandas as pd
 
 from data_learning.ingest_stage import normalize_record
-from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, run_model
+from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, normalize_versions, run_model
 
 from tests.helpers import make_arxiv_record
 
@@ -14,8 +14,8 @@ def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
     output_dir = tmp_path / "modeled"
 
     records = [
-        normalize_record(make_arxiv_record(1, version_count=2, year=2020)),
-        normalize_record(make_arxiv_record(2, version_count=1, year=2021)),
+        normalize_record(make_arxiv_record(1, version_count=2, year=2020))[0],
+        normalize_record(make_arxiv_record(2, version_count=1, year=2021))[0],
     ]
 
     pd.DataFrame(records).to_parquet(input_path, index=False)
@@ -37,3 +37,17 @@ def test_build_fact_and_dates_raises_on_empty_versions():
     frame = pd.DataFrame([{"id": "0000001", "versions": "[]"}])
     with pytest.raises(ValueError, match="no versions"):
         build_fact_and_dates(frame)
+
+
+def test_normalize_versions_accepts_raw_ingest_payload():
+    raw_versions = [
+        {"version": "v2", "created": "Tue, 02 Feb 2021 00:00:00 GMT"},
+        {"version": "v1", "created": "Wed, 01 Jan 2020 00:00:00 GMT"},
+    ]
+
+    normalized = normalize_versions(raw_versions)
+
+    assert normalized == [
+        {"version_number": 1, "created_date": "2020-01-01"},
+        {"version_number": 2, "created_date": "2021-02-02"},
+    ]

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -25,8 +25,6 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
             str(raw_input),
             "--output",
             str(validated_path),
-            "--limit",
-            "100",
         ],
         [
             sys.executable,
@@ -66,7 +64,7 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
         )
 
     validated_frame = pd.read_parquet(validated_path)
-    assert len(validated_frame) == 100
+    assert len(validated_frame) == len(records)
     assert (output_dir / "csv" / "fact_submissions.csv").exists()
     assert (output_dir / "parquet" / "fact_submissions.parquet").exists()
     assert "year\tsubmission_count" in completed[-1].stdout

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -65,6 +65,7 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
 
     validated_frame = pd.read_parquet(validated_path)
     assert len(validated_frame) == len(records)
+    assert (modeled_dir / "dim_papers.parquet").exists()
     assert (output_dir / "csv" / "fact_submissions.csv").exists()
     assert (output_dir / "parquet" / "fact_submissions.parquet").exists()
     assert "year\tsubmission_count" in completed[-1].stdout


### PR DESCRIPTION
## Summary
- expand Stage 2 modeling to write fact_submissions, dim_dates, and dim_papers
- add behavior-focused tests and a CLI smoke assertion for the new modeled output
- document the star schema design, add CLAUDE.md, and ignore local Hypothesis state

## Testing
- PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q