### PR TITLE
Implement core Stage 2 star schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .claude/settings.local.json
 .DS_Store
 __pycache__/
+.hypothesis/
 .pytest_cache/
 .venv/
 *.egg-info/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@ When making changes, preserve that distinction unless the user explicitly asks t
   - `src/store.py`
   - `src/query.py`
   - shared logic under `src/data_learning/`
+  - core Stage 2 star schema outputs: `fact_submissions`, `dim_dates`, `dim_papers`
   - stage tests and one end-to-end CLI smoke test
 - Not implemented yet:
   - full ingestion validation/reporting
-  - `dim_papers`
   - authors/categories dimensions and bridge tables
   - SCD Type 2 logic
   - Avro output and benchmarks
@@ -47,6 +47,7 @@ PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
   - `submission_key`
   - `paper_id`
   - `version_number`
+  - `paper_key`
   - `date_key`
   - `is_first_submission`
   - `is_latest_version`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
 
-For repository-specific instructions, conventions, and current implementation boundaries, see [AGENTS.md](/Users/brian/dev/data-learning/AGENTS.md).
+For repository-specific instructions, conventions, and current implementation boundaries, see [AGENTS.md](AGENTS.md).
 
 Treat `AGENTS.md` as the source of truth for this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+For repository-specific instructions, conventions, and current implementation boundaries, see [AGENTS.md](/Users/brian/dev/data-learning/AGENTS.md).
+
+Treat `AGENTS.md` as the source of truth for this repo.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This repository currently implements issue `#3`: a thin end-to-end slice that pr
 The implemented pipeline processes a small sample of the raw arXiv JSONL snapshot through four stages:
 
 1. `ingest`: read JSONL, keep the first 100 valid records, and write validated Parquet
-2. `model`: build a minimal `fact_submissions` table and `dim_dates`
+2. `model`: build the core Stage 2 star schema tables `fact_submissions`, `dim_dates`, and `dim_papers`
 3. `store`: write `fact_submissions` to CSV and Parquet outputs
 4. `query`: run one DuckDB query for submission counts by year
 
-This is intentionally narrower than the full Phase 1 spec. It does not yet include full validation/logging, `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
+This is intentionally narrower than the full Phase 1 spec. It does not yet include full validation/logging, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
 
 ## Project layout
 
@@ -274,6 +274,7 @@ The current tracer bullet writes:
 - `data/raw/arxiv_validated.parquet`
 - `data/modeled/fact_submissions.parquet`
 - `data/modeled/dim_dates.parquet`
+- `data/modeled/dim_papers.parquet`
 - `data/output/csv/fact_submissions.csv`
 - `data/output/parquet/fact_submissions.parquet`
 

--- a/docs/star-schema-vs-snowflake.md
+++ b/docs/star-schema-vs-snowflake.md
@@ -1,0 +1,171 @@
+# Star Schema vs Snowflake
+
+This note compares the two common dimensional-modeling shapes and explains why the current Stage 2 implementation uses a star schema.
+
+It is a companion to [`docs/star-schema.md`](/Users/brian/dev/data-learning/docs/star-schema.md), which describes the concrete tables implemented in this repository.
+
+## Short version
+
+- use a star schema when the priority is simple analytical queries, understandable joins, and predictable reporting behavior
+- use a snowflake schema when the priority is stricter normalization inside dimensions and dimension reuse matters more than query simplicity
+
+For this project, the star schema is the better fit.
+
+## What a star schema means
+
+In a star schema:
+
+- the fact table sits in the center
+- dimensions connect directly to the fact table
+- dimension tables are relatively denormalized
+
+In this repository, the current shape is:
+
+- `fact_submissions`
+- `dim_dates`
+- `dim_papers`
+
+That is a star because the modeled tables are intended to join directly to the fact table rather than through additional sub-dimensions.
+
+## What a snowflake schema means
+
+In a snowflake schema:
+
+- the fact table still sits at the center
+- some dimensions are normalized into additional tables
+- the query path from fact to business attributes usually requires more joins
+
+In a fuller arXiv model, a snowflake design might split data further into shapes like:
+
+- `dim_papers` -> publisher or license sub-dimensions
+- category tables broken into group and subcategory lookup tables
+- author name components broken into additional lookup tables
+
+That design is more normalized, but it also pushes more join logic into every analytical query.
+
+## Tradeoffs
+
+### Star schema advantages
+
+- simpler SQL for reporting and exploration
+- fewer joins for common analytical queries
+- easier for new contributors to understand
+- better fit for BI-style workflows where facts are filtered and aggregated repeatedly
+- dimensions can carry friendly attributes directly without repeated lookup hops
+
+### Star schema costs
+
+- more duplicated attribute data inside dimensions
+- dimension tables may be wider
+- some updates can require touching more than one row if attributes are repeated
+
+### Snowflake advantages
+
+- less redundancy inside dimensions
+- stricter normalization of hierarchical or reusable reference data
+- can make sense when dimension maintenance is the main concern
+- can help when the same normalized reference entities need to be governed consistently across many models
+
+### Snowflake costs
+
+- more joins in nearly every analytical query
+- more cognitive overhead for readers of the model
+- more places for foreign-key issues or missing joins to show up
+- can make a small learning project feel more complex than the reporting needs justify
+
+## Query use cases
+
+### Good fit for a star schema
+
+Star schemas work well when the main questions look like:
+
+- how many submissions happened by year or month
+- which papers have multiple versions
+- how many first submissions versus updates are there
+- how do submission counts change over time
+
+These are fact-first questions. They usually filter or group the fact table and join directly to a small number of descriptive dimensions.
+
+### Better fit for a snowflake schema
+
+Snowflake schemas are more attractive when the main questions depend on reusable hierarchies or heavily shared reference data, for example:
+
+- many models need one canonical category-group hierarchy
+- the same normalized author, institution, or license entities are maintained centrally
+- dimension maintenance and governance are more important than ad hoc query readability
+
+That is not the current situation in this repository.
+
+## Why this repo uses a star schema
+
+The current Stage 2 choice is deliberate.
+
+Reasons:
+
+- the project is about learning dimensional modeling, not maximizing normalization depth
+- the current query layer is simple and analytical
+- the implemented dimensions are small and easy to reason about directly
+- the current scope does not yet include the richer dimension network where snowflaking would even become a serious option
+- the model should stay readable for tests, docs, and local inspection
+
+Put differently: the extra complexity of a snowflake model would be paid immediately, while most of its benefits would remain theoretical in this repo's current scope.
+
+## Concrete examples in this project
+
+### Example: `dim_dates`
+
+Star-oriented choice:
+
+- keep all calendar attributes on `dim_dates`
+
+Why:
+
+- queries can group by `year`, `quarter`, `month_name`, or `day_name` without additional joins
+
+Snowflake alternative:
+
+- split date parts into separate tables or separate hierarchical lookups
+
+Why that is not useful here:
+
+- it would complicate every query without reducing meaningful operational cost
+
+### Example: `dim_papers`
+
+Star-oriented choice:
+
+- keep paper metadata directly on `dim_papers`
+
+Why:
+
+- paper-level descriptive attributes are naturally consumed together
+- analysts usually want title, abstract, DOI, comments, and license together when they inspect a paper dimension row
+
+Snowflake alternative:
+
+- split some descriptive fields into separate reference tables
+
+Why that is not useful here:
+
+- there is no current need to normalize those fields into reusable shared dimensions
+
+## When this decision might change
+
+A future issue might justify more snowflaking if the project grows to include:
+
+- category hierarchies used across multiple fact tables
+- reusable author or institution dimensions with their own maintenance workflows
+- broader warehouse-style governance requirements
+- reporting patterns where dimension normalization clearly reduces duplication without hurting usability too much
+
+If that happens, the right move would be to introduce those changes intentionally and document the new query tradeoffs, not to snowflake the model opportunistically during unrelated work.
+
+## Practical recommendation for this repo
+
+For the current repository:
+
+- keep `fact_submissions` as the central event table
+- keep `dim_dates` and `dim_papers` directly joinable from the fact table
+- add future dimensions and bridge tables in a star-oriented shape unless there is a clear, concrete reason to normalize further
+
+That keeps the model aligned with the current learning goals, test design, and query workload.

--- a/docs/star-schema-vs-snowflake.md
+++ b/docs/star-schema-vs-snowflake.md
@@ -2,7 +2,7 @@
 
 This note compares the two common dimensional-modeling shapes and explains why the current Stage 2 implementation uses a star schema.
 
-It is a companion to [`docs/star-schema.md`](/Users/brian/dev/data-learning/docs/star-schema.md), which describes the concrete tables implemented in this repository.
+It is a companion to [`docs/star-schema.md`](./star-schema.md), which describes the concrete tables implemented in this repository.
 
 ## Short version
 

--- a/docs/star-schema.md
+++ b/docs/star-schema.md
@@ -1,6 +1,6 @@
 # Stage 2 Star Schema
 
-This note describes the Stage 2 dimensional model implemented in [`src/data_learning/model_stage.py`](/Users/brian/dev/data-learning/src/data_learning/model_stage.py).
+This note describes the Stage 2 dimensional model implemented in [`src/data_learning/model_stage.py`](../src/data_learning/model_stage.py).
 
 The current modeled schema centers on three tables:
 

--- a/docs/star-schema.md
+++ b/docs/star-schema.md
@@ -1,0 +1,151 @@
+# Stage 2 Star Schema
+
+This note explains the current Stage 2 modeling design implemented in [`src/data_learning/model_stage.py`](/Users/brian/dev/data-learning/src/data_learning/model_stage.py).
+
+The repository now writes three modeled Parquet tables under `data/modeled/`:
+
+- `fact_submissions.parquet`
+- `dim_dates.parquet`
+- `dim_papers.parquet`
+
+This is the core star schema from issue `#5`. It is intentionally narrower than the full Phase 1 spec: bridge tables and SCD Type 2 behavior are still out of scope.
+
+## Schema overview
+
+### `fact_submissions`
+
+This is the central fact table.
+
+Current grain:
+
+- one row per paper-version submission event
+
+Current columns:
+
+- `submission_key`
+- `paper_id`
+- `version_number`
+- `paper_key`
+- `date_key`
+- `is_first_submission`
+- `is_latest_version`
+
+Why this grain:
+
+- the raw arXiv data already expresses version history as repeated version entries per paper
+- one row per paper-version keeps that submission history explicit
+- analytical queries such as "how many updates happened" or "which submissions were latest" become simple filters and counts
+
+Tradeoff:
+
+- this creates more fact rows than a one-row-per-paper model
+- but the extra rows reflect real submission events, which is the more useful analytical shape for this project
+
+### `dim_papers`
+
+This dimension has one row per unique `paper_id`.
+
+Current columns:
+
+- `paper_key`
+- `paper_id`
+- `title`
+- `abstract`
+- `doi`
+- `journal_ref`
+- `comments`
+- `license`
+- `valid_from`
+- `valid_to`
+- `is_current`
+
+Implementation choice:
+
+- `paper_key` is a surrogate key assigned deterministically from sorted `paper_id` values
+- `valid_from`, `valid_to`, and `is_current` are present now as placeholders for later SCD work
+- for issue `#5`, every paper row is current, `valid_to` is null, and `valid_from` is the first submission date
+
+Tradeoff:
+
+- this is not a full historical dimension yet
+- but it keeps the schema compatible with the next modeling issue without pretending SCD Type 2 is already implemented
+
+### `dim_dates`
+
+This is a calendar dimension keyed by `date_key` in `YYYYMMDD` form.
+
+Current columns:
+
+- `date_key`
+- `full_date`
+- `year`
+- `quarter`
+- `month`
+- `month_name`
+- `day_of_week`
+- `day_name`
+- `is_weekend`
+
+Implementation choice:
+
+- the dimension is generated for every calendar day from the earliest submission date to the latest submission date, inclusive
+- it is not limited to dates that appear directly in the fact table
+
+Tradeoff:
+
+- this writes more rows than a sparse "observed dates only" table
+- but it makes the date dimension behave like a real analytic calendar dimension and supports simpler joins and future reporting
+
+## Why a star schema here
+
+Stage 2 uses a star schema rather than a snowflake design.
+
+Reasons:
+
+- the main queries are analytical and join-driven, not OLTP updates
+- denormalized dimensions are easier to understand in a learning project
+- a star schema keeps the relationship between events and dimensions visible without extra join depth
+
+Tradeoff:
+
+- a snowflake model could reduce some duplication inside dimensions
+- but it would add complexity without improving the current query patterns or learning goals
+
+## Surrogate keys versus natural keys
+
+The model keeps both:
+
+- `paper_id` as the natural arXiv identifier
+- `paper_key` as the warehouse-style surrogate key
+
+Why both exist:
+
+- `paper_id` is readable and maps directly back to the source data
+- `paper_key` gives the model a stable dimension join key
+- surrogate keys are the standard pattern once dimensions may need historical versioning
+
+Tradeoff:
+
+- keeping both keys adds one more column to the fact table
+- but it avoids repainting the schema later when SCD logic is added
+
+## Determinism and testability
+
+The current implementation favors deterministic outputs:
+
+- `paper_key` assignment is based on sorted `paper_id`
+- all modeled outputs are written from explicit input and output paths
+- tests can build temporary fixtures and assert exact row values
+
+This is a good fit for a local batch pipeline because reruns should produce the same outputs from the same validated input.
+
+## Known limits of the current implementation
+
+What is intentionally not implemented yet:
+
+- SCD Type 2 behavior in `dim_papers`
+- author and category dimensions
+- bridge tables for paper-author and paper-category relationships
+- later storage-format and dashboard work from later stages
+
+That boundary matters because the current code should describe the implemented core star schema accurately without implying the rest of Phase 1 already exists.

--- a/docs/star-schema.md
+++ b/docs/star-schema.md
@@ -1,14 +1,14 @@
 # Stage 2 Star Schema
 
-This note explains the current Stage 2 modeling design implemented in [`src/data_learning/model_stage.py`](/Users/brian/dev/data-learning/src/data_learning/model_stage.py).
+This note describes the Stage 2 dimensional model implemented in [`src/data_learning/model_stage.py`](/Users/brian/dev/data-learning/src/data_learning/model_stage.py).
 
-The repository now writes three modeled Parquet tables under `data/modeled/`:
+The current modeled schema centers on three tables:
 
 - `fact_submissions.parquet`
 - `dim_dates.parquet`
 - `dim_papers.parquet`
 
-This is the core star schema from issue `#5`. It is intentionally narrower than the full Phase 1 spec: bridge tables and SCD Type 2 behavior are still out of scope.
+Together they form a compact star schema for analytical work over arXiv submission history. The model is intentionally narrower than a fuller warehouse-style design: bridge tables and full SCD Type 2 behavior are not part of the current implementation.
 
 ## Schema overview
 
@@ -16,11 +16,11 @@ This is the core star schema from issue `#5`. It is intentionally narrower than 
 
 This is the central fact table.
 
-Current grain:
+Grain:
 
 - one row per paper-version submission event
 
-Current columns:
+Columns:
 
 - `submission_key`
 - `paper_id`
@@ -39,13 +39,13 @@ Why this grain:
 Tradeoff:
 
 - this creates more fact rows than a one-row-per-paper model
-- but the extra rows reflect real submission events, which is the more useful analytical shape for this project
+- but the extra rows reflect real submission events, which is the more useful analytical shape for this dataset and query pattern
 
 ### `dim_papers`
 
 This dimension has one row per unique `paper_id`.
 
-Current columns:
+Columns:
 
 - `paper_key`
 - `paper_id`
@@ -62,19 +62,19 @@ Current columns:
 Implementation choice:
 
 - `paper_key` is a surrogate key assigned deterministically from sorted `paper_id` values
-- `valid_from`, `valid_to`, and `is_current` are present now as placeholders for later SCD work
-- for issue `#5`, every paper row is current, `valid_to` is null, and `valid_from` is the first submission date
+- `valid_from`, `valid_to`, and `is_current` are present to support historical dimension patterns
+- in the current implementation, each paper has one current row, `valid_to` is null, and `valid_from` is the first submission date
 
 Tradeoff:
 
 - this is not a full historical dimension yet
-- but it keeps the schema compatible with the next modeling issue without pretending SCD Type 2 is already implemented
+- but it keeps the schema compatible with future historical-dimension work without pretending SCD Type 2 is already implemented
 
 ### `dim_dates`
 
 This is a calendar dimension keyed by `date_key` in `YYYYMMDD` form.
 
-Current columns:
+Columns:
 
 - `date_key`
 - `full_date`
@@ -139,13 +139,13 @@ The current implementation favors deterministic outputs:
 
 This is a good fit for a local batch pipeline because reruns should produce the same outputs from the same validated input.
 
-## Known limits of the current implementation
+## Scope limits
 
-What is intentionally not implemented yet:
+Some dimensional-modeling capabilities are intentionally outside the current schema:
 
 - SCD Type 2 behavior in `dim_papers`
 - author and category dimensions
 - bridge tables for paper-author and paper-category relationships
 - later storage-format and dashboard work from later stages
 
-That boundary matters because the current code should describe the implemented core star schema accurately without implying the rest of Phase 1 already exists.
+That boundary matters because this document is meant to describe the current model accurately without implying a broader warehouse design that is not yet present.

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -54,6 +54,9 @@ DATE_COLUMNS = [
     "is_weekend",
 ]
 
+MAX_DATE_DIMENSION_SPAN_DAYS = 366 * 200
+
+
 def normalize_versions(value: Any) -> list[dict[str, Any]]:
     raw_versions = json_loads_if_needed(value)
     if raw_versions is None:
@@ -86,9 +89,27 @@ def normalize_versions(value: Any) -> list[dict[str, Any]]:
     return normalized_versions
 
 
+def validate_date_dimension_range(start_date: date | None, end_date: date | None) -> None:
+    if start_date is None or end_date is None:
+        return
+
+    if end_date < start_date:
+        raise ValueError(f"invalid submission date range: {start_date.isoformat()} > {end_date.isoformat()}")
+
+    span_days = (end_date - start_date).days + 1
+    if span_days > MAX_DATE_DIMENSION_SPAN_DAYS:
+        raise ValueError(
+            "submission date range is too large to build a contiguous dim_dates table: "
+            f"{start_date.isoformat()} to {end_date.isoformat()} ({span_days} days, "
+            f"max {MAX_DATE_DIMENSION_SPAN_DAYS})"
+        )
+
+
 def build_date_dimension(start_date: date | None, end_date: date | None) -> pd.DataFrame:
     if start_date is None or end_date is None:
         return pd.DataFrame(columns=DATE_COLUMNS)
+
+    validate_date_dimension_range(start_date, end_date)
 
     date_rows = []
     current_date = start_date

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -20,9 +20,24 @@ FACT_COLUMNS = [
     "submission_key",
     "paper_id",
     "version_number",
+    "paper_key",
     "date_key",
     "is_first_submission",
     "is_latest_version",
+]
+
+PAPER_COLUMNS = [
+    "paper_key",
+    "paper_id",
+    "title",
+    "abstract",
+    "doi",
+    "journal_ref",
+    "comments",
+    "license",
+    "valid_from",
+    "valid_to",
+    "is_current",
 ]
 
 DATE_COLUMNS = [
@@ -37,13 +52,76 @@ DATE_COLUMNS = [
     "is_weekend",
 ]
 
+def build_date_dimension(start_date: date | None, end_date: date | None) -> pd.DataFrame:
+    if start_date is None or end_date is None:
+        return pd.DataFrame(columns=DATE_COLUMNS)
 
-def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    date_rows = []
+    current_date = start_date
+    while current_date <= end_date:
+        date_rows.append(
+            {
+                "date_key": date_to_key(current_date),
+                "full_date": current_date.isoformat(),
+                "year": current_date.year,
+                "quarter": ((current_date.month - 1) // 3) + 1,
+                "month": current_date.month,
+                "month_name": current_date.strftime("%B"),
+                "day_of_week": current_date.weekday(),
+                "day_name": current_date.strftime("%A"),
+                "is_weekend": current_date.weekday() >= 5,
+            }
+        )
+        current_date += timedelta(days=1)
+
+    return pd.DataFrame(date_rows, columns=DATE_COLUMNS)
+
+
+def build_paper_dimension(records: list[dict[str, Any]]) -> tuple[pd.DataFrame, dict[str, int]]:
+    paper_rows: list[dict[str, Any]] = []
+    paper_keys: dict[str, int] = {}
+
+    for paper_key, row in enumerate(sorted(records, key=lambda item: item["id"]), start=1):
+        paper_id = row["id"]
+        if paper_id in paper_keys:
+            raise ValueError(f"duplicate paper id: {paper_id}")
+
+        versions = json_loads_if_needed(row["versions"])
+        if not versions:
+            raise ValueError(f"paper {paper_id} has no versions")
+
+        first_submission_date = date.fromisoformat(versions[0]["created_date"])
+        paper_keys[paper_id] = paper_key
+        paper_rows.append(
+            {
+                "paper_key": paper_key,
+                "paper_id": paper_id,
+                "title": row.get("title"),
+                "abstract": row.get("abstract"),
+                "doi": row.get("doi"),
+                "journal_ref": row.get("journal_ref"),
+                "comments": row.get("comments"),
+                "license": row.get("license"),
+                "valid_from": first_submission_date.isoformat(),
+                "valid_to": None,
+                "is_current": True,
+            }
+        )
+
+    return pd.DataFrame(paper_rows, columns=PAPER_COLUMNS), paper_keys
+
+
+def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    records = validated_frame.to_dict(orient="records")
+    paper_frame, paper_keys = build_paper_dimension(records)
     fact_rows: list[dict[str, Any]] = []
-    unique_dates: dict[int, date] = {}
+    min_submission_date: date | None = None
+    max_submission_date: date | None = None
     submission_key = 1
 
-    for row in validated_frame.to_dict(orient="records"):
+    # The fact table grain is one submission event per paper-version. Keeping the fact at that
+    # event grain makes version history explicit without forcing query-time array parsing.
+    for row in records:
         versions = json_loads_if_needed(row["versions"])
         if not versions:
             raise ValueError(f"paper {row['id']} has no versions")
@@ -52,12 +130,16 @@ def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, p
         for version in versions:
             created_date = date.fromisoformat(version["created_date"])
             date_key = date_to_key(created_date)
-            unique_dates[date_key] = created_date
+            min_submission_date = created_date if min_submission_date is None else min(min_submission_date, created_date)
+            max_submission_date = created_date if max_submission_date is None else max(max_submission_date, created_date)
             fact_rows.append(
                 {
                     "submission_key": submission_key,
                     "paper_id": row["id"],
                     "version_number": version["version_number"],
+                    # The natural arXiv id stays on the fact for readability, but the surrogate
+                    # key gives us a stable join target for dimensional modeling and later SCD work.
+                    "paper_key": paper_keys[row["id"]],
                     "date_key": date_key,
                     "is_first_submission": version["version_number"] == 1,
                     "is_latest_version": version["version_number"] == latest_version_number,
@@ -66,52 +148,52 @@ def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, p
             submission_key += 1
 
     fact_frame = pd.DataFrame(fact_rows, columns=FACT_COLUMNS)
-
-    date_rows = []
-    for date_key, full_date in sorted(unique_dates.items()):
-        date_rows.append(
-            {
-                "date_key": date_key,
-                "full_date": full_date.isoformat(),
-                "year": full_date.year,
-                "quarter": ((full_date.month - 1) // 3) + 1,
-                "month": full_date.month,
-                "month_name": full_date.strftime("%B"),
-                "day_of_week": full_date.weekday(),
-                "day_name": full_date.strftime("%A"),
-                "is_weekend": full_date.weekday() >= 5,
-            }
-        )
-
-    date_frame = pd.DataFrame(date_rows, columns=DATE_COLUMNS)
-    return fact_frame, date_frame
+    # This stays a star schema instead of snowflaking further because the learning goal here is
+    # straightforward analytical joins over a small set of conformed dimensions, not extra
+    # normalization depth that would add joins without clarifying the query model.
+    date_frame = build_date_dimension(min_submission_date, max_submission_date)
+    return fact_frame, date_frame, paper_frame
 
 
-def write_modeled_outputs(fact_frame: pd.DataFrame, date_frame: pd.DataFrame, output_dir: Path) -> dict[str, Path]:
+def write_modeled_outputs(
+    fact_frame: pd.DataFrame,
+    date_frame: pd.DataFrame,
+    paper_frame: pd.DataFrame,
+    output_dir: Path,
+) -> dict[str, Path]:
     ensure_directory(output_dir)
     fact_path = output_dir / "fact_submissions.parquet"
     date_path = output_dir / "dim_dates.parquet"
+    paper_path = output_dir / "dim_papers.parquet"
     fact_frame.to_parquet(fact_path, index=False)
     date_frame.to_parquet(date_path, index=False)
+    paper_frame.to_parquet(paper_path, index=False)
     return {
         "fact_submissions": fact_path,
         "dim_dates": date_path,
+        "dim_papers": paper_path,
     }
 
 
 def run_model(input_path: Path, output_dir: Path) -> dict[str, Any]:
     validated_frame = pd.read_parquet(input_path)
-    fact_frame, date_frame = build_fact_and_dates(validated_frame)
-    outputs = write_modeled_outputs(fact_frame=fact_frame, date_frame=date_frame, output_dir=output_dir)
+    fact_frame, date_frame, paper_frame = build_fact_and_dates(validated_frame)
+    outputs = write_modeled_outputs(
+        fact_frame=fact_frame,
+        date_frame=date_frame,
+        paper_frame=paper_frame,
+        output_dir=output_dir,
+    )
     return {
         "fact_rows": len(fact_frame),
         "date_rows": len(date_frame),
+        "paper_rows": len(paper_frame),
         "outputs": outputs,
     }
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build minimal fact and date dimensions from validated data.")
+    parser = argparse.ArgumentParser(description="Build core star schema tables from validated data.")
     parser.add_argument("--input", type=path_arg, default=DEFAULT_VALIDATED_PATH, help="Path to the validated Parquet input.")
     parser.add_argument("--output-dir", type=path_arg, default=DEFAULT_MODELED_DIR, help="Directory for modeled Parquet outputs.")
     return parser
@@ -121,7 +203,8 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     result = run_model(input_path=args.input, output_dir=args.output_dir)
     print(
-        f"Created {result['fact_rows']} fact rows and {result['date_rows']} date rows "
+        f"Created {result['fact_rows']} fact rows, {result['date_rows']} date rows, "
+        f"and {result['paper_rows']} paper rows "
         f"under {args.output_dir}"
     )
     return 0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -103,6 +103,40 @@ def test_build_fact_and_dates_uses_valid_dimension_keys():
     assert fact_frame["is_latest_version"].tolist() == [False, False, True, True]
 
 
+def test_build_fact_and_dates_rejects_pathological_date_span():
+    frame = pd.DataFrame(
+        [
+            {
+                "id": "0000001",
+                "title": "Paper 1",
+                "abstract": "Abstract for paper 1",
+                "doi": None,
+                "journal_ref": None,
+                "comments": None,
+                "license": "CC0",
+                "versions": [
+                    {"version_number": 1, "created_date": "2020-01-01"},
+                ],
+            },
+            {
+                "id": "0000002",
+                "title": "Paper 2",
+                "abstract": "Abstract for paper 2",
+                "doi": None,
+                "journal_ref": None,
+                "comments": None,
+                "license": "CC0",
+                "versions": [
+                    {"version_number": 1, "created_date": "9999-12-31"},
+                ],
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="submission date range is too large"):
+        build_fact_and_dates(frame)
+
+
 def test_normalize_versions_accepts_raw_ingest_payload():
     raw_versions = [
         {"version": "v2", "created": "Tue, 02 Feb 2021 00:00:00 GMT"},

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,12 +4,18 @@ import pytest
 import pandas as pd
 
 from data_learning.ingest_stage import normalize_record
-from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, run_model
+from data_learning.model_stage import (
+    DATE_COLUMNS,
+    FACT_COLUMNS,
+    PAPER_COLUMNS,
+    build_fact_and_dates,
+    run_model,
+)
 
 from tests.helpers import make_arxiv_record
 
 
-def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
+def test_run_model_builds_core_star_schema_tables(tmp_path):
     input_path = tmp_path / "validated.parquet"
     output_dir = tmp_path / "modeled"
 
@@ -24,16 +30,73 @@ def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
 
     fact_frame = pd.read_parquet(output_dir / "fact_submissions.parquet")
     date_frame = pd.read_parquet(output_dir / "dim_dates.parquet")
+    paper_frame = pd.read_parquet(output_dir / "dim_papers.parquet")
+    expected_dates = pd.date_range("2020-01-01", "2021-02-02", freq="D")
 
     assert result["fact_rows"] == 3
+    assert result["paper_rows"] == 2
+    assert result["date_rows"] == len(expected_dates)
+    assert set(result["outputs"]) == {"fact_submissions", "dim_dates", "dim_papers"}
     assert fact_frame.columns.tolist() == FACT_COLUMNS
     assert date_frame.columns.tolist() == DATE_COLUMNS
+    assert paper_frame.columns.tolist() == PAPER_COLUMNS
+    assert fact_frame["paper_key"].tolist() == [1, 1, 2]
     assert fact_frame["is_first_submission"].tolist() == [True, False, True]
     assert fact_frame["is_latest_version"].tolist() == [False, True, True]
-    assert date_frame["date_key"].tolist() == [20200101, 20210101, 20210202]
+    assert date_frame["date_key"].tolist()[0] == 20200101
+    assert date_frame["date_key"].tolist()[-1] == 20210202
+    assert paper_frame.to_dict(orient="records") == [
+        {
+            "paper_key": 1,
+            "paper_id": "0000001",
+            "title": "Paper 1",
+            "abstract": "Abstract for paper 1",
+            "doi": None,
+            "journal_ref": None,
+            "comments": None,
+            "license": "CC0",
+            "valid_from": "2020-01-01",
+            "valid_to": None,
+            "is_current": True,
+        },
+        {
+            "paper_key": 2,
+            "paper_id": "0000002",
+            "title": "Paper 2",
+            "abstract": "Abstract for paper 2",
+            "doi": None,
+            "journal_ref": None,
+            "comments": None,
+            "license": "CC0",
+            "valid_from": "2021-01-01",
+            "valid_to": None,
+            "is_current": True,
+        },
+    ]
 
 
 def test_build_fact_and_dates_raises_on_empty_versions():
     frame = pd.DataFrame([{"id": "0000001", "versions": "[]"}])
     with pytest.raises(ValueError, match="no versions"):
         build_fact_and_dates(frame)
+
+
+def test_build_fact_and_dates_uses_valid_dimension_keys():
+    frame = pd.DataFrame(
+        [
+            normalize_record(make_arxiv_record(2, version_count=3, year=2020)),
+            normalize_record(make_arxiv_record(1, version_count=1, year=2021)),
+        ]
+    )
+
+    fact_frame, date_frame, paper_frame = build_fact_and_dates(frame)
+
+    assert len(fact_frame) == 4
+    assert len(paper_frame) == 2
+    assert len(fact_frame) >= len(paper_frame)
+    assert set(fact_frame["paper_key"]) == set(paper_frame["paper_key"])
+    assert set(fact_frame["date_key"]).issubset(set(date_frame["date_key"]))
+    assert fact_frame["version_number"].tolist() == [1, 2, 3, 1]
+    assert fact_frame["paper_key"].tolist() == [2, 2, 2, 1]
+    assert fact_frame["is_first_submission"].tolist() == [True, False, False, True]
+    assert fact_frame["is_latest_version"].tolist() == [False, False, True, True]

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -67,6 +67,8 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
 
     validated_frame = pd.read_parquet(validated_path)
     assert len(validated_frame) == 100
+    assert (modeled_dir / "dim_papers.parquet").exists()
+    assert len(validated_frame) == 100
     assert (output_dir / "csv" / "fact_submissions.csv").exists()
     assert (output_dir / "parquet" / "fact_submissions.parquet").exists()
     assert "year\tsubmission_count" in completed[-1].stdout


### PR DESCRIPTION
## Summary
This PR implements issue #5 by expanding Stage 2 from a minimal fact-plus-date output into the current core star schema.

The branch now:
- adds `dim_papers` as a modeled output
- adds `paper_key` to `fact_submissions`
- generates `dim_dates` across the full inclusive submission-date range instead of only observed dates
- documents the current star-schema design and repo-agent conventions
- ignores local Hypothesis state

## Main Changes
### Stage 2 modeling
- `src/data_learning/model_stage.py` now writes three modeled Parquet tables: `fact_submissions`, `dim_dates`, and `dim_papers`
- `fact_submissions` keeps the existing one-row-per-paper-version grain and now includes deterministic `paper_key` values
- `dim_papers` is one row per `paper_id` with the requested SCD placeholder columns: `valid_from`, `valid_to`, and `is_current`
- `dim_dates` is generated as a contiguous calendar dimension from the earliest submission date through the latest submission date
- inline comments explain fact grain, surrogate versus natural keys, and why the stage uses a star schema instead of snowflaking further

### Tests
- `tests/test_model.py` now covers:
  - three-table modeled output creation
  - `paper_key` assignment
  - contiguous date-dimension generation
  - foreign-key integrity between fact and dimensions
  - version-number and first/latest-version behavior
  - raw-ingest version normalization compatibility
- `tests/test_pipeline_smoke.py` now asserts that the CLI pipeline writes `dim_papers.parquet`

### Documentation and repo metadata
- `docs/star-schema.md` documents the implemented schema, design decisions, and current tradeoffs
- `README.md` and `AGENTS.md` were updated to reflect the actual implemented Stage 2 scope
- `CLAUDE.md` now points back to `AGENTS.md` as the repo-specific source of truth
- `.gitignore` now ignores `.hypothesis/`

## Files Of Interest
- `src/data_learning/model_stage.py`
- `tests/test_model.py`
- `tests/test_pipeline_smoke.py`
- `docs/star-schema.md`
- `README.md`
- `AGENTS.md`

## Automated Testing
Passed locally:
- `PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q`

## Manual Testing
### 1. Environment setup
1. Create or refresh the virtual environment if needed.
2. Install the project in editable mode.

```bash
python3 -m venv .venv
./.venv/bin/pip install --upgrade pip setuptools wheel
./.venv/bin/pip install -e .
```

### 2. Run the automated test suite
```bash
PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
```
Expected result:
- all tests pass

### 3. Run the pipeline manually on a local snapshot
Use either the Kaggle snapshot or a smaller local fixture.

```bash
./.venv/bin/python src/ingest.py \
  --input data/arxiv-metadata-oai-snapshot.json \
  --output data/raw/arxiv_validated.parquet

./.venv/bin/python src/model.py \
  --input data/raw/arxiv_validated.parquet \
  --output-dir data/modeled

./.venv/bin/python src/store.py \
  --input data/modeled/fact_submissions.parquet \
  --output-dir data/output

./.venv/bin/python src/query.py \
  --fact-path data/output/parquet/fact_submissions.parquet \
  --date-dim-path data/modeled/dim_dates.parquet
```
Expected result:
- `src/model.py` reports fact, date, and paper row counts
- `data/modeled/fact_submissions.parquet` exists
- `data/modeled/dim_dates.parquet` exists
- `data/modeled/dim_papers.parquet` exists
- `src/query.py` prints a tab-separated `year` / `submission_count` result

### 4. Inspect modeled outputs
Check the three modeled tables directly.

```bash
./.venv/bin/python - <<"PY"
import pandas as pd

fact = pd.read_parquet("data/modeled/fact_submissions.parquet")
dates = pd.read_parquet("data/modeled/dim_dates.parquet")
papers = pd.read_parquet("data/modeled/dim_papers.parquet")

print(fact.head())
print(dates.head())
print(papers.head())
print(fact.columns.tolist())
print(dates.columns.tolist())
print(papers.columns.tolist())
PY
```
Expected checks:
- `fact_submissions` includes `paper_key`
- `dim_papers` includes `paper_key`, `paper_id`, `valid_from`, `valid_to`, and `is_current`
- `dim_dates` has calendar attributes such as `year`, `quarter`, `month_name`, and `is_weekend`

### 5. Verify relational integrity manually
```bash
./.venv/bin/python - <<"PY"
import pandas as pd

fact = pd.read_parquet("data/modeled/fact_submissions.parquet")
dates = pd.read_parquet("data/modeled/dim_dates.parquet")
papers = pd.read_parquet("data/modeled/dim_papers.parquet")

print(set(fact["date_key"]).issubset(set(dates["date_key"])))
print(set(fact["paper_key"]).issubset(set(papers["paper_key"])))
print((fact.groupby("paper_id")["is_latest_version"].sum() == 1).all())
PY
```
Expected result:
- all three printed values are `True`

## Notes
- This PR intentionally does not implement authors/categories dimensions, bridge tables, or SCD Type 2 row versioning
- `dim_papers` includes SCD placeholder columns only; full SCD behavior remains future work
- `store` and `query` stay functionally narrow and continue operating on `fact_submissions` plus `dim_dates`