### PR TITLE
[backflow] Build core star schema tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ When making changes, preserve that distinction unless the user explicitly asks t
   - `src/query.py`
   - shared logic under `src/data_learning/`
   - full ingestion validation/logging that writes validated raw Parquet
+  - Stage 2 core star schema tables: `fact_submissions`, `dim_dates`, `dim_papers`
   - stage tests and one end-to-end CLI smoke test
 - Not implemented yet:
-  - `dim_papers`
   - authors/categories dimensions and bridge tables
   - SCD Type 2 logic
   - Avro output and benchmarks
@@ -47,6 +47,7 @@ PYTHONPYCACHEPREFIX=/tmp/data-learning-pyc ./.venv/bin/pytest -q
   - `submission_key`
   - `paper_id`
   - `version_number`
+  - `paper_key`
   - `date_key`
   - `is_first_submission`
   - `is_latest_version`

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This repository currently implements full Stage 1 ingestion from issue `#4`, plu
 The implemented pipeline currently covers the four stages below, with Stage 1 implemented fully and later stages still intentionally minimal:
 
 1. `ingest`: stream JSONL, validate records, log drops, and write validated Parquet
-2. `model`: build a minimal `fact_submissions` table and `dim_dates`
+2. `model`: build the core star schema tables `fact_submissions`, `dim_dates`, and `dim_papers`
 3. `store`: write `fact_submissions` to CSV and Parquet outputs
 4. `query`: run one DuckDB query for submission counts by year
 
-The repository is still narrower than the full Phase 1 spec. It does not yet include `dim_papers`, bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
+The repository is still narrower than the full Phase 1 spec. It does not yet include authors/categories bridge tables, SCD Type 2 behavior, Avro output, benchmarks, or the Streamlit dashboard.
 
 ## Project layout
 
@@ -273,6 +273,7 @@ The current implementation writes:
 - `data/raw/arxiv_validated.parquet`
 - `data/modeled/fact_submissions.parquet`
 - `data/modeled/dim_dates.parquet`
+- `data/modeled/dim_papers.parquet`
 - `data/output/csv/fact_submissions.csv`
 - `data/output/parquet/fact_submissions.parquet`
 

--- a/src/data_learning/model_stage.py
+++ b/src/data_learning/model_stage.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +22,7 @@ FACT_COLUMNS = [
     "submission_key",
     "paper_id",
     "version_number",
+    "paper_key",
     "date_key",
     "is_first_submission",
     "is_latest_version",
@@ -37,6 +38,20 @@ DATE_COLUMNS = [
     "day_of_week",
     "day_name",
     "is_weekend",
+]
+
+PAPER_COLUMNS = [
+    "paper_key",
+    "paper_id",
+    "title",
+    "abstract",
+    "doi",
+    "journal_ref",
+    "comments",
+    "license",
+    "is_current",
+    "valid_from",
+    "valid_to",
 ]
 
 
@@ -72,27 +87,115 @@ def normalize_versions(value: Any) -> list[dict[str, Any]]:
     return normalized_versions
 
 
-def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
-    fact_rows: list[dict[str, Any]] = []
-    unique_dates: dict[int, date] = {}
-    submission_key = 1
+def _build_date_dimension(start_date: date, end_date: date) -> pd.DataFrame:
+    date_rows: list[dict[str, Any]] = []
+    current_date = start_date
+
+    while current_date <= end_date:
+        date_rows.append(
+            {
+                "date_key": date_to_key(current_date),
+                "full_date": current_date.isoformat(),
+                "year": current_date.year,
+                "quarter": ((current_date.month - 1) // 3) + 1,
+                "month": current_date.month,
+                "month_name": current_date.strftime("%B"),
+                "day_of_week": current_date.weekday(),
+                "day_name": current_date.strftime("%A"),
+                "is_weekend": current_date.weekday() >= 5,
+            }
+        )
+        current_date += timedelta(days=1)
+
+    return pd.DataFrame(date_rows, columns=DATE_COLUMNS)
+
+
+def _extract_paper_rows(validated_frame: pd.DataFrame) -> tuple[list[dict[str, Any]], list[date]]:
+    paper_rows: list[dict[str, Any]] = []
+    first_submission_dates: list[date] = []
+    seen_paper_ids: set[str] = set()
 
     for row in validated_frame.to_dict(orient="records"):
+        paper_id = row["id"]
+        if paper_id in seen_paper_ids:
+            raise ValueError(f"duplicate paper id in validated input: {paper_id}")
+        seen_paper_ids.add(paper_id)
+
         versions = normalize_versions(row["versions"])
         if not versions:
-            raise ValueError(f"paper {row['id']} has no versions")
-        latest_version_number = max(version["version_number"] for version in versions)
+            raise ValueError(f"paper {paper_id} has no versions")
 
-        for version in versions:
+        first_submission_date = date.fromisoformat(versions[0]["created_date"])
+        first_submission_dates.append(first_submission_date)
+        paper_rows.append(
+            {
+                "paper_id": paper_id,
+                "title": row["title"],
+                "abstract": row["abstract"],
+                "doi": row["doi"],
+                "journal_ref": row["journal_ref"],
+                "comments": row["comments"],
+                "license": row["license"],
+                "is_current": True,
+                "valid_from": first_submission_date.isoformat(),
+                "valid_to": None,
+                "versions": versions,
+            }
+        )
+
+    return paper_rows, first_submission_dates
+
+
+def build_star_schema(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    paper_rows, first_submission_dates = _extract_paper_rows(validated_frame)
+    if not paper_rows:
+        empty_fact = pd.DataFrame(columns=FACT_COLUMNS)
+        empty_dates = pd.DataFrame(columns=DATE_COLUMNS)
+        empty_papers = pd.DataFrame(columns=PAPER_COLUMNS)
+        return empty_fact, empty_dates, empty_papers
+
+    sorted_papers = sorted(paper_rows, key=lambda row: row["paper_id"])
+    paper_key_by_id: dict[str, int] = {}
+    dim_paper_rows: list[dict[str, Any]] = []
+    all_submission_dates = list(first_submission_dates)
+
+    # This stage models a star schema so the fact table stays narrow and analytic joins stay simple.
+    # Snowflaking categories/authors into more dimensions happens later when that scope is requested.
+    for paper_key, paper in enumerate(sorted_papers, start=1):
+        paper_key_by_id[paper["paper_id"]] = paper_key
+        dim_paper_rows.append(
+            {
+                # The surrogate key gives the warehouse a stable join target even if source metadata
+                # changes later; the natural arXiv id is still retained for traceability.
+                "paper_key": paper_key,
+                "paper_id": paper["paper_id"],
+                "title": paper["title"],
+                "abstract": paper["abstract"],
+                "doi": paper["doi"],
+                "journal_ref": paper["journal_ref"],
+                "comments": paper["comments"],
+                "license": paper["license"],
+                "is_current": paper["is_current"],
+                "valid_from": paper["valid_from"],
+                "valid_to": paper["valid_to"],
+            }
+        )
+
+    fact_rows: list[dict[str, Any]] = []
+    submission_key = 1
+    for paper in paper_rows:
+        latest_version_number = max(version["version_number"] for version in paper["versions"])
+        for version in paper["versions"]:
             created_date = date.fromisoformat(version["created_date"])
-            date_key = date_to_key(created_date)
-            unique_dates[date_key] = created_date
+            all_submission_dates.append(created_date)
             fact_rows.append(
                 {
+                    # The fact grain is one row per paper-version submission event.
                     "submission_key": submission_key,
-                    "paper_id": row["id"],
+                    "paper_id": paper["paper_id"],
                     "version_number": version["version_number"],
-                    "date_key": date_key,
+                    "paper_key": paper_key_by_id[paper["paper_id"]],
+                    "date_key": date_to_key(created_date),
                     "is_first_submission": version["version_number"] == 1,
                     "is_latest_version": version["version_number"] == latest_version_number,
                 }
@@ -100,52 +203,50 @@ def build_fact_and_dates(validated_frame: pd.DataFrame) -> tuple[pd.DataFrame, p
             submission_key += 1
 
     fact_frame = pd.DataFrame(fact_rows, columns=FACT_COLUMNS)
-
-    date_rows = []
-    for date_key, full_date in sorted(unique_dates.items()):
-        date_rows.append(
-            {
-                "date_key": date_key,
-                "full_date": full_date.isoformat(),
-                "year": full_date.year,
-                "quarter": ((full_date.month - 1) // 3) + 1,
-                "month": full_date.month,
-                "month_name": full_date.strftime("%B"),
-                "day_of_week": full_date.weekday(),
-                "day_name": full_date.strftime("%A"),
-                "is_weekend": full_date.weekday() >= 5,
-            }
-        )
-
-    date_frame = pd.DataFrame(date_rows, columns=DATE_COLUMNS)
-    return fact_frame, date_frame
+    date_frame = _build_date_dimension(min(all_submission_dates), max(all_submission_dates))
+    paper_frame = pd.DataFrame(dim_paper_rows, columns=PAPER_COLUMNS)
+    return fact_frame, date_frame, paper_frame
 
 
-def write_modeled_outputs(fact_frame: pd.DataFrame, date_frame: pd.DataFrame, output_dir: Path) -> dict[str, Path]:
+def write_modeled_outputs(
+    fact_frame: pd.DataFrame,
+    date_frame: pd.DataFrame,
+    paper_frame: pd.DataFrame,
+    output_dir: Path,
+) -> dict[str, Path]:
     ensure_directory(output_dir)
     fact_path = output_dir / "fact_submissions.parquet"
     date_path = output_dir / "dim_dates.parquet"
+    paper_path = output_dir / "dim_papers.parquet"
     fact_frame.to_parquet(fact_path, index=False)
     date_frame.to_parquet(date_path, index=False)
+    paper_frame.to_parquet(paper_path, index=False)
     return {
         "fact_submissions": fact_path,
         "dim_dates": date_path,
+        "dim_papers": paper_path,
     }
 
 
 def run_model(input_path: Path, output_dir: Path) -> dict[str, Any]:
     validated_frame = pd.read_parquet(input_path)
-    fact_frame, date_frame = build_fact_and_dates(validated_frame)
-    outputs = write_modeled_outputs(fact_frame=fact_frame, date_frame=date_frame, output_dir=output_dir)
+    fact_frame, date_frame, paper_frame = build_star_schema(validated_frame)
+    outputs = write_modeled_outputs(
+        fact_frame=fact_frame,
+        date_frame=date_frame,
+        paper_frame=paper_frame,
+        output_dir=output_dir,
+    )
     return {
         "fact_rows": len(fact_frame),
         "date_rows": len(date_frame),
+        "paper_rows": len(paper_frame),
         "outputs": outputs,
     }
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build minimal fact and date dimensions from validated data.")
+    parser = argparse.ArgumentParser(description="Build the core star schema tables from validated data.")
     parser.add_argument("--input", type=path_arg, default=DEFAULT_VALIDATED_PATH, help="Path to the validated Parquet input.")
     parser.add_argument("--output-dir", type=path_arg, default=DEFAULT_MODELED_DIR, help="Directory for modeled Parquet outputs.")
     return parser
@@ -155,7 +256,8 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     result = run_model(input_path=args.input, output_dir=args.output_dir)
     print(
-        f"Created {result['fact_rows']} fact rows and {result['date_rows']} date rows "
+        f"Created {result['fact_rows']} fact rows, {result['date_rows']} date rows, "
+        f"and {result['paper_rows']} paper rows "
         f"under {args.output_dir}"
     )
     return 0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 import pandas as pd
 
 from data_learning.ingest_stage import normalize_record
-from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, build_fact_and_dates, normalize_versions, run_model
+from data_learning.model_stage import DATE_COLUMNS, FACT_COLUMNS, PAPER_COLUMNS, build_star_schema, normalize_versions, run_model
 
 from tests.helpers import make_arxiv_record
 
 
-def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
+def test_run_model_builds_core_star_schema_outputs(tmp_path):
     input_path = tmp_path / "validated.parquet"
     output_dir = tmp_path / "modeled"
 
@@ -24,19 +26,59 @@ def test_run_model_builds_fact_submissions_and_dim_dates(tmp_path):
 
     fact_frame = pd.read_parquet(output_dir / "fact_submissions.parquet")
     date_frame = pd.read_parquet(output_dir / "dim_dates.parquet")
+    paper_frame = pd.read_parquet(output_dir / "dim_papers.parquet")
 
     assert result["fact_rows"] == 3
+    assert result["paper_rows"] == 2
     assert fact_frame.columns.tolist() == FACT_COLUMNS
     assert date_frame.columns.tolist() == DATE_COLUMNS
+    assert paper_frame.columns.tolist() == PAPER_COLUMNS
     assert fact_frame["is_first_submission"].tolist() == [True, False, True]
     assert fact_frame["is_latest_version"].tolist() == [False, True, True]
-    assert date_frame["date_key"].tolist() == [20200101, 20210101, 20210202]
+    assert fact_frame["paper_key"].tolist() == [1, 1, 2]
+    assert date_frame.iloc[0]["date_key"] == 20200101
+    assert date_frame.iloc[-1]["date_key"] == 20210202
+    assert len(date_frame) == (date(2021, 2, 2) - date(2020, 1, 1)).days + 1
+    assert paper_frame[["paper_key", "paper_id"]].to_dict(orient="records") == [
+        {"paper_key": 1, "paper_id": "0000001"},
+        {"paper_key": 2, "paper_id": "0000002"},
+    ]
+    assert paper_frame["is_current"].tolist() == [True, True]
+    assert paper_frame["valid_from"].tolist() == ["2020-01-01", "2021-01-01"]
+    assert paper_frame["valid_to"].isna().all()
+    assert set(fact_frame["date_key"]).issubset(set(date_frame["date_key"]))
+    assert set(fact_frame["paper_key"]).issubset(set(paper_frame["paper_key"]))
 
 
-def test_build_fact_and_dates_raises_on_empty_versions():
+def test_build_star_schema_raises_on_empty_versions():
     frame = pd.DataFrame([{"id": "0000001", "versions": "[]"}])
     with pytest.raises(ValueError, match="no versions"):
-        build_fact_and_dates(frame)
+        build_star_schema(frame)
+
+
+def test_build_star_schema_raises_on_duplicate_paper_ids():
+    record, _ = normalize_record(make_arxiv_record(1, version_count=1, year=2020))
+    assert record is not None
+    frame = pd.DataFrame([record, record])
+
+    with pytest.raises(ValueError, match="duplicate paper id"):
+        build_star_schema(frame)
+
+
+def test_build_star_schema_preserves_version_numbering_and_date_completeness():
+    records = [
+        normalize_record(make_arxiv_record(7, version_count=3, year=2020))[0],
+    ]
+    frame = pd.DataFrame(records)
+
+    fact_frame, date_frame, paper_frame = build_star_schema(frame)
+
+    assert fact_frame["version_number"].tolist() == [1, 2, 3]
+    assert fact_frame["paper_key"].tolist() == [1, 1, 1]
+    assert len(fact_frame) >= len(paper_frame)
+    assert date_frame.iloc[0]["date_key"] == 20200101
+    assert date_frame.iloc[-1]["date_key"] == 20220303
+    assert len(date_frame) == 793
 
 
 def test_normalize_versions_accepts_raw_ingest_payload():

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -65,6 +65,7 @@ def test_pipeline_runs_end_to_end_via_cli(tmp_path):
 
     validated_frame = pd.read_parquet(validated_path)
     assert len(validated_frame) == len(records)
+    assert (modeled_dir / "dim_papers.parquet").exists()
     assert (output_dir / "csv" / "fact_submissions.csv").exists()
     assert (output_dir / "parquet" / "fact_submissions.parquet").exists()
     assert "year\tsubmission_count" in completed[-1].stdout

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -11,9 +11,9 @@ def test_yearly_submission_counts_queries_parquet_files(tmp_path):
 
     pd.DataFrame(
         [
-            {"submission_key": 1, "paper_id": "a", "version_number": 1, "date_key": 20200101, "is_first_submission": True, "is_latest_version": True},
-            {"submission_key": 2, "paper_id": "b", "version_number": 1, "date_key": 20200101, "is_first_submission": True, "is_latest_version": True},
-            {"submission_key": 3, "paper_id": "c", "version_number": 1, "date_key": 20210101, "is_first_submission": True, "is_latest_version": True},
+            {"submission_key": 1, "paper_id": "a", "version_number": 1, "paper_key": 1, "date_key": 20200101, "is_first_submission": True, "is_latest_version": True},
+            {"submission_key": 2, "paper_id": "b", "version_number": 1, "paper_key": 2, "date_key": 20200101, "is_first_submission": True, "is_latest_version": True},
+            {"submission_key": 3, "paper_id": "c", "version_number": 1, "paper_key": 3, "date_key": 20210101, "is_first_submission": True, "is_latest_version": True},
         ]
     ).to_parquet(fact_path, index=False)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,6 +15,7 @@ def test_run_store_writes_csv_and_parquet_outputs(tmp_path):
                 "submission_key": 1,
                 "paper_id": "0000001",
                 "version_number": 1,
+                "paper_key": 1,
                 "date_key": 20200101,
                 "is_first_submission": True,
                 "is_latest_version": True,


### PR DESCRIPTION
## Summary
- build `dim_papers`, full-range `dim_dates`, and `fact_submissions` with `paper_key` in the model stage
- add Stage 2 tests for FK integrity, date completeness, and version numbering while keeping the existing CLI smoke flow green
- update `README.md` and `AGENTS.md` to reflect the implemented Stage 2 scope without introducing later-phase features

## Why
Issue #5 asks for the current Stage 2 foundation: the core star schema tables written to `data/modeled/`, including surrogate keys and placeholder SCD columns for papers, while deferring SCD Type 2 and later dimensions to future work.